### PR TITLE
Fixed the wrong documentation issue for the RotateAnimatedTextKit method

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,7 @@ Row(
       },
       text: ["AWESOME", "OPTIMISTIC", "DIFFERENT"],
       textStyle: TextStyle(fontSize: 40.0, fontFamily: "Horizon"),
-      textAlign: TextAlign.start,
-      alignment: AlignmentDirectional.topStart // or Alignment.topLeft
+      textAlign: TextAlign.start
     ),
   ],
 );


### PR DESCRIPTION
## RotateAnimatedTextKit

So, I'm just trying [animated_text_kit](https://pub.dev/packages?q=animated_text_kit) plugin. 
While taking the **Usage** case of **README.md** into consideration.
Founded that for the **_Rotate_** text Usage example for the **RotateAnimatedTextKit( )** method  you implemented the **_alignment_** property as ```alignment: AlignmentDirectional.topStart``` which will disable the **RotateAnimatedTextKit( )** behaviour, while giving the error as **type '_MixedAlignment' is not a subtype of type 'Alignment'**

Nothing more fancy, I just removed that error causing line from README.md :) .
Thankyou ✌.