### PR TITLE
Refactored code to move default logic from the State class to the StatefulWidget

### DIFF
--- a/lib/src/fade.dart
+++ b/lib/src/fade.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
 import 'dart:async';
 import 'dart:math';
+import 'package:flutter/material.dart';
 
 class FadeAnimatedTextKit extends StatefulWidget {
   /// List of [String] that would be displayed subsequently in the animation.
@@ -75,24 +75,34 @@ class FadeAnimatedTextKit extends StatefulWidget {
   /// By default it is set to false.
   final bool stopPauseOnTap;
 
-  const FadeAnimatedTextKit(
-      {Key key,
-      @required this.text,
-      this.duration,
-      this.textStyle,
-      this.pause,
-      this.displayFullTextOnTap = false,
-      this.stopPauseOnTap = false,
-      this.onTap,
-      this.onNext,
-      this.onNextBeforePause,
-      this.onFinished,
-      this.totalRepeatCount = 3,
-      this.alignment = AlignmentDirectional.topStart,
-      this.textAlign = TextAlign.start,
-      this.repeatForever = false,
-      this.isRepeatingAnimation = true})
-      : super(key: key);
+  const FadeAnimatedTextKit({
+    Key key,
+    @required this.text,
+    this.duration = const Duration(milliseconds: 2000),
+    this.textStyle,
+    this.pause = const Duration(milliseconds: 500),
+    this.displayFullTextOnTap = false,
+    this.stopPauseOnTap = false,
+    this.onTap,
+    this.onNext,
+    this.onNextBeforePause,
+    this.onFinished,
+    this.totalRepeatCount = 3,
+    this.alignment = AlignmentDirectional.topStart,
+    this.textAlign = TextAlign.start,
+    this.repeatForever = false,
+    this.isRepeatingAnimation = true,
+  })  : assert(null != text),
+        assert(null != duration),
+        assert(null != pause),
+        assert(null != displayFullTextOnTap),
+        assert(null != stopPauseOnTap),
+        assert(null != totalRepeatCount),
+        assert(null != alignment),
+        assert(null != textAlign),
+        assert(null != repeatForever),
+        assert(null != isRepeatingAnimation),
+        super(key: key);
 
   @override
   _FadeTextState createState() => _FadeTextState();
@@ -103,11 +113,8 @@ class _FadeTextState extends State<FadeAnimatedTextKit>
   Animation _fadeIn, _fadeOut;
 
   AnimationController _controller;
-  List<Widget> textWidgetList = [];
 
-  Duration _pause;
-
-  List<Map<String, dynamic>> _texts = [];
+  final _texts = <Map<String, dynamic>>[];
 
   int _index;
 
@@ -117,22 +124,19 @@ class _FadeTextState extends State<FadeAnimatedTextKit>
 
   int _currentRepeatCount;
 
-  Duration _duration;
-
   @override
   void initState() {
     super.initState();
-
-    _pause = widget.pause ?? const Duration(milliseconds: 500);
 
     _index = -1;
 
     _currentRepeatCount = 0;
 
-    _duration = widget.duration ?? const Duration(milliseconds: 2000);
-
     widget.text.forEach((text) {
-      _texts.add({'text': text, 'pause': _pause});
+      _texts.add({
+        'text': text,
+        'pause': widget.pause,
+      });
     });
 
     _initAnimation();
@@ -174,18 +178,23 @@ class _FadeTextState extends State<FadeAnimatedTextKit>
 
   void _initAnimation() {
     _controller = AnimationController(
-      duration: _duration,
+      duration: widget.duration,
       vsync: this,
     );
 
-    _fadeIn = Tween<double>(begin: 0.0, end: 1.0).animate(CurvedAnimation(
+    _fadeIn = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(
         parent: _controller,
-        curve: const Interval(0.0, 0.5, curve: Curves.linear)));
+        curve: const Interval(0.0, 0.5, curve: Curves.linear),
+      ),
+    );
 
-    _fadeOut = Tween<double>(begin: 1.0, end: 0.0).animate(CurvedAnimation(
+    _fadeOut = Tween<double>(begin: 1.0, end: 0.0).animate(
+      CurvedAnimation(
         parent: _controller,
-        curve: const Interval(0.8, 1.0, curve: Curves.linear)))
-      ..addStatusListener(_animationEndCallback);
+        curve: const Interval(0.8, 1.0, curve: Curves.linear),
+      ),
+    )..addStatusListener(_animationEndCallback);
   }
 
   void _nextAnimation() {

--- a/lib/src/rotate.dart
+++ b/lib/src/rotate.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'dart:async';
+import 'package:flutter/material.dart';
 
 class RotateAnimatedTextKit extends StatefulWidget {
   /// List of [String] that would be displayed subsequently in the animation.
@@ -74,24 +74,33 @@ class RotateAnimatedTextKit extends StatefulWidget {
   /// By default it is set to false.
   final bool displayFullTextOnTap;
 
-  const RotateAnimatedTextKit(
-      {Key key,
-      @required this.text,
-      this.textStyle,
-      this.transitionHeight,
-      this.pause,
-      this.onNext,
-      this.onNextBeforePause,
-      this.onFinished,
-      this.totalRepeatCount = 3,
-      this.duration,
-      this.onTap,
-      this.alignment = const Alignment(0.0, 0.0),
-      this.textAlign = TextAlign.start,
-      this.displayFullTextOnTap = false,
-      this.repeatForever = false,
-      this.isRepeatingAnimation = true})
-      : super(key: key);
+  const RotateAnimatedTextKit({
+    Key key,
+    @required this.text,
+    this.textStyle,
+    this.transitionHeight,
+    this.pause = const Duration(milliseconds: 500),
+    this.onNext,
+    this.onNextBeforePause,
+    this.onFinished,
+    this.totalRepeatCount = 3,
+    this.duration = const Duration(milliseconds: 2000),
+    this.onTap,
+    this.alignment = const Alignment(0.0, 0.0),
+    this.textAlign = TextAlign.start,
+    this.displayFullTextOnTap = false,
+    this.repeatForever = false,
+    this.isRepeatingAnimation = true,
+  })  : assert(null != text),
+        assert(null != pause),
+        assert(null != totalRepeatCount),
+        assert(null != duration),
+        assert(null != alignment),
+        assert(null != textAlign),
+        assert(null != displayFullTextOnTap),
+        assert(null != repeatForever),
+        assert(null != isRepeatingAnimation),
+        super(key: key);
 
   @override
   _RotatingTextState createState() => _RotatingTextState();
@@ -105,11 +114,7 @@ class _RotatingTextState extends State<RotateAnimatedTextKit>
 
   Animation _fadeIn, _fadeOut, _slideIn, _slideOut;
 
-  List<Widget> textWidgetList = [];
-
-  Duration _pause;
-
-  List<Map<String, dynamic>> _texts = [];
+  final _texts = <Map<String, dynamic>>[];
 
   int _index;
 
@@ -119,22 +124,22 @@ class _RotatingTextState extends State<RotateAnimatedTextKit>
 
   int _currentRepeatCount;
 
-  Duration _duration;
-
   @override
   void initState() {
     super.initState();
 
-    _pause = widget.pause ?? const Duration(milliseconds: 500);
+    _transitionHeight =
+        widget.transitionHeight ?? (widget.textStyle.fontSize * 10 / 3);
 
     _index = -1;
 
     _currentRepeatCount = 0;
 
-    _duration = widget.duration ?? const Duration(milliseconds: 2000);
-
     widget.text.forEach((text) {
-      _texts.add({'text': text, 'pause': _pause});
+      _texts.add({
+        'text': text,
+        'pause': widget.pause,
+      });
     });
 
     _initAnimation();
@@ -169,10 +174,10 @@ class _RotatingTextState extends State<RotateAnimatedTextKit>
                   return AlignTransition(
                     alignment: _slideIn.value.y != 0.0 ? _slideIn : _slideOut,
                     child: Opacity(
-                        opacity: _fadeIn.value != 1.0
-                            ? _fadeIn.value
-                            : _fadeOut.value,
-                        child: child),
+                      opacity:
+                          _fadeIn.value != 1.0 ? _fadeIn.value : _fadeOut.value,
+                      child: child,
+                    ),
                   );
                 },
               ),
@@ -182,45 +187,62 @@ class _RotatingTextState extends State<RotateAnimatedTextKit>
 
   void _initAnimation() {
     _controller = AnimationController(
-      duration: _duration,
+      duration: widget.duration,
       vsync: this,
     );
 
     if (_index == 0) {
       _slideIn = AlignmentTween(
-              begin: Alignment(-1.0, -1.0).add(widget.alignment),
-              end: Alignment(-1.0, 0.0).add(widget.alignment))
-          .animate(CurvedAnimation(
-              parent: _controller,
-              curve: const Interval(0.0, 0.4, curve: Curves.linear)));
-
-      _fadeIn = Tween<double>(begin: 0.0, end: 1.0).animate(CurvedAnimation(
+        begin: const Alignment(-1.0, -1.0) + widget.alignment,
+        end: const Alignment(-1.0, 0.0) + widget.alignment,
+      ).animate(
+        CurvedAnimation(
           parent: _controller,
-          curve: const Interval(0.0, 0.4, curve: Curves.easeOut)));
+          curve: const Interval(0.0, 0.4, curve: Curves.linear),
+        ),
+      );
+
+      _fadeIn = Tween<double>(begin: 0.0, end: 1.0).animate(
+        CurvedAnimation(
+          parent: _controller,
+          curve: const Interval(0.0, 0.4, curve: Curves.easeOut),
+        ),
+      );
     } else {
       _slideIn = AlignmentTween(
-              begin: Alignment(-1.0, -1.0).add(widget.alignment),
-              end: Alignment(-1.0, 0.0).add(widget.alignment))
-          .animate(CurvedAnimation(
-              parent: _controller,
-              curve: const Interval(0.0, 0.4, curve: Curves.linear)));
-
-      _fadeIn = Tween<double>(begin: 0.0, end: 1.0).animate(CurvedAnimation(
+        begin: const Alignment(-1.0, -1.0) + widget.alignment,
+        end: const Alignment(-1.0, 0.0) + widget.alignment,
+      ).animate(
+        CurvedAnimation(
           parent: _controller,
-          curve: const Interval(0.0, 0.4, curve: Curves.easeOut)));
+          curve: const Interval(0.0, 0.4, curve: Curves.linear),
+        ),
+      );
+
+      _fadeIn = Tween<double>(begin: 0.0, end: 1.0).animate(
+        CurvedAnimation(
+          parent: _controller,
+          curve: const Interval(0.0, 0.4, curve: Curves.easeOut),
+        ),
+      );
     }
 
     _slideOut = AlignmentTween(
-      begin: Alignment(-1.0, 0.0).add(widget.alignment),
-      end: Alignment(-1.0, 1.0).add(widget.alignment),
-    ).animate(CurvedAnimation(
+      begin: const Alignment(-1.0, 0.0) + widget.alignment,
+      end: const Alignment(-1.0, 1.0) + widget.alignment,
+    ).animate(
+      CurvedAnimation(
         parent: _controller,
-        curve: const Interval(0.7, 1.0, curve: Curves.linear)));
+        curve: const Interval(0.7, 1.0, curve: Curves.linear),
+      ),
+    );
 
-    _fadeOut = Tween<double>(begin: 1.0, end: 0.0).animate(CurvedAnimation(
+    _fadeOut = Tween<double>(begin: 1.0, end: 0.0).animate(
+      CurvedAnimation(
         parent: _controller,
-        curve: const Interval(0.7, 1.0, curve: Curves.easeIn)))
-      ..addStatusListener(_animationEndCallback);
+        curve: const Interval(0.7, 1.0, curve: Curves.easeIn),
+      ),
+    )..addStatusListener(_animationEndCallback);
   }
 
   void _nextAnimation() {
@@ -250,12 +272,6 @@ class _RotatingTextState extends State<RotateAnimatedTextKit>
     }
 
     if (mounted) setState(() {});
-
-    if (widget.transitionHeight == null) {
-      _transitionHeight = widget.textStyle.fontSize * 10 / 3;
-    } else {
-      _transitionHeight = widget.transitionHeight;
-    }
 
     _controller.forward(from: 0.0);
   }

--- a/lib/src/scale.dart
+++ b/lib/src/scale.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
 import 'dart:async';
 import 'dart:math';
+import 'package:flutter/material.dart';
 
 class ScaleAnimatedTextKit extends StatefulWidget {
   /// List of [String] that would be displayed subsequently in the animation.
@@ -80,25 +80,36 @@ class ScaleAnimatedTextKit extends StatefulWidget {
   /// By default it is set to false.
   final bool stopPauseOnTap;
 
-  const ScaleAnimatedTextKit(
-      {Key key,
-      @required this.text,
-      this.textStyle,
-      this.scalingFactor = 0.5,
-      this.pause,
-      this.duration,
-      this.onTap,
-      this.onNext,
-      this.onNextBeforePause,
-      this.onFinished,
-      this.totalRepeatCount = 3,
-      this.alignment = AlignmentDirectional.topStart,
-      this.textAlign = TextAlign.start,
-      this.repeatForever = false,
-      this.isRepeatingAnimation = true,
-      this.displayFullTextOnTap = false,
-      this.stopPauseOnTap = false})
-      : super(key: key);
+  const ScaleAnimatedTextKit({
+    Key key,
+    @required this.text,
+    this.textStyle,
+    this.scalingFactor = 0.5,
+    this.pause = const Duration(milliseconds: 500),
+    this.duration = const Duration(milliseconds: 2000),
+    this.onTap,
+    this.onNext,
+    this.onNextBeforePause,
+    this.onFinished,
+    this.totalRepeatCount = 3,
+    this.alignment = AlignmentDirectional.topStart,
+    this.textAlign = TextAlign.start,
+    this.repeatForever = false,
+    this.isRepeatingAnimation = true,
+    this.displayFullTextOnTap = false,
+    this.stopPauseOnTap = false,
+  })  : assert(null != text),
+        assert(null != scalingFactor),
+        assert(null != pause),
+        assert(null != duration),
+        assert(null != totalRepeatCount),
+        assert(null != alignment),
+        assert(null != textAlign),
+        assert(null != repeatForever),
+        assert(null != isRepeatingAnimation),
+        assert(null != displayFullTextOnTap),
+        assert(null != stopPauseOnTap),
+        super(key: key);
 
   @override
   _ScaleTextState createState() => _ScaleTextState();
@@ -109,11 +120,8 @@ class _ScaleTextState extends State<ScaleAnimatedTextKit>
   AnimationController _controller;
 
   Animation _fadeIn, _fadeOut, _scaleIn, _scaleOut;
-  List<Widget> textWidgetList = [];
 
-  Duration _pause;
-
-  List<Map<String, dynamic>> _texts = [];
+  final _texts = <Map<String, dynamic>>[];
 
   int _index;
 
@@ -123,22 +131,19 @@ class _ScaleTextState extends State<ScaleAnimatedTextKit>
 
   int _currentRepeatCount;
 
-  Duration _duration;
-
   @override
   void initState() {
     super.initState();
-
-    _pause = widget.pause ?? const Duration(milliseconds: 500);
 
     _index = -1;
 
     _currentRepeatCount = 0;
 
-    _duration = widget.duration ?? const Duration(milliseconds: 2000);
-
     widget.text.forEach((text) {
-      _texts.add({'text': text, 'pause': _pause});
+      _texts.add({
+        'text': text,
+        'pause': widget.pause,
+      });
     });
 
     // init controller and animations
@@ -185,35 +190,36 @@ class _ScaleTextState extends State<ScaleAnimatedTextKit>
 
   void _initAnimation() {
     _controller = AnimationController(
-      duration: _duration,
+      duration: widget.duration,
       vsync: this,
     );
 
-    _fadeIn = Tween<double>(begin: 0.0, end: 1.0).animate(CurvedAnimation(
+    _fadeIn = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(
         parent: _controller,
-        curve: const Interval(0.0, 0.5, curve: Curves.easeOut)));
+        curve: const Interval(0.0, 0.5, curve: Curves.easeOut),
+      ),
+    );
 
-    _fadeOut = Tween<double>(begin: 1.0, end: 0.0).animate(CurvedAnimation(
+    _fadeOut = Tween<double>(begin: 1.0, end: 0.0).animate(
+      CurvedAnimation(
         parent: _controller,
-        curve: const Interval(0.5, 1.0, curve: Curves.easeOut)));
+        curve: const Interval(0.5, 1.0, curve: Curves.easeOut),
+      ),
+    );
 
-    _scaleIn = Tween<double>(begin: widget.scalingFactor, end: 1.0)
-        .animate(CurvedAnimation(
-            parent: _controller,
-            curve: const Interval(
-              0.0,
-              0.5,
-              curve: Curves.easeOut,
-            )));
-    _scaleOut = Tween<double>(begin: 1.0, end: widget.scalingFactor)
-        .animate(CurvedAnimation(
-            parent: _controller,
-            curve: const Interval(
-              0.5,
-              1.0,
-              curve: Curves.easeIn,
-            )))
-          ..addStatusListener(_animationEndCallback);
+    _scaleIn = Tween<double>(begin: widget.scalingFactor, end: 1.0).animate(
+      CurvedAnimation(
+        parent: _controller,
+        curve: const Interval(0.0, 0.5, curve: Curves.easeOut),
+      ),
+    );
+    _scaleOut = Tween<double>(begin: 1.0, end: widget.scalingFactor).animate(
+      CurvedAnimation(
+        parent: _controller,
+        curve: const Interval(0.5, 1.0, curve: Curves.easeIn),
+      ),
+    )..addStatusListener(_animationEndCallback);
   }
 
   void _nextAnimation() {
@@ -274,7 +280,7 @@ class _ScaleTextState extends State<ScaleAnimatedTextKit>
         }
       } else {
         final int pause = _texts[_index]['pause'].inMilliseconds;
-        final int left = _duration.inMilliseconds;
+        final int left = widget.duration.inMilliseconds;
 
         _controller.stop();
 

--- a/lib/src/typer.dart
+++ b/lib/src/typer.dart
@@ -1,7 +1,7 @@
+import 'dart:async';
+import 'dart:math';
 import 'package:characters/characters.dart';
 import 'package:flutter/material.dart';
-import 'dart:math';
-import 'dart:async';
 
 class TyperAnimatedTextKit extends StatefulWidget {
   /// List of [String] that would be displayed subsequently in the animation.
@@ -74,11 +74,19 @@ class TyperAnimatedTextKit extends StatefulWidget {
     this.alignment = AlignmentDirectional.topStart,
     this.textAlign = TextAlign.start,
     this.isRepeatingAnimation = true,
-    this.speed,
-    this.pause,
+    this.speed = const Duration(milliseconds: 40),
+    this.pause = const Duration(milliseconds: 1000),
     this.displayFullTextOnTap = false,
     this.stopPauseOnTap = false,
-  }) : super(key: key);
+  })  : assert(null != text),
+        assert(null != alignment),
+        assert(null != textAlign),
+        assert(null != isRepeatingAnimation),
+        assert(null != speed),
+        assert(null != pause),
+        assert(null != displayFullTextOnTap),
+        assert(null != stopPauseOnTap),
+        super(key: key);
 
   @override
   _TyperState createState() => _TyperState();
@@ -88,12 +96,8 @@ class _TyperState extends State<TyperAnimatedTextKit>
     with TickerProviderStateMixin {
   AnimationController _controller;
   Animation _typingText;
-  List<Widget> textWidgetList = [];
 
-  Duration _speed;
-  Duration _pause;
-
-  List<Map<String, dynamic>> _texts = [];
+  final _texts = <Map<String, dynamic>>[];
 
   int _index;
 
@@ -105,17 +109,14 @@ class _TyperState extends State<TyperAnimatedTextKit>
   void initState() {
     super.initState();
 
-    _speed = widget.speed ?? const Duration(milliseconds: 40);
-    _pause = widget.pause ?? const Duration(milliseconds: 1000);
-
     _index = -1;
 
     widget.text.forEach((text) {
       _texts.add({
         'text': text,
         'chars': text.characters,
-        'speed': _speed,
-        'pause': _pause,
+        'speed': widget.speed,
+        'pause': widget.pause,
       });
     });
 

--- a/lib/src/typewriter.dart
+++ b/lib/src/typewriter.dart
@@ -1,7 +1,7 @@
-import 'package:characters/characters.dart';
-import 'package:flutter/material.dart';
 import 'dart:async';
 import 'dart:math';
+import 'package:characters/characters.dart';
+import 'package:flutter/material.dart';
 
 class TypewriterAnimatedTextKit extends StatefulWidget {
   /// List of [String] that would be displayed subsequently in the animation.
@@ -74,24 +74,33 @@ class TypewriterAnimatedTextKit extends StatefulWidget {
   /// By default it is set to false.
   final bool stopPauseOnTap;
 
-  TypewriterAnimatedTextKit(
-      {Key key,
-      @required this.text,
-      this.textStyle,
-      this.speed,
-      this.pause,
-      this.displayFullTextOnTap = false,
-      this.stopPauseOnTap = false,
-      this.onTap,
-      this.onNext,
-      this.onNextBeforePause,
-      this.onFinished,
-      this.totalRepeatCount = 3,
-      this.alignment = AlignmentDirectional.topStart,
-      this.textAlign = TextAlign.start,
-      this.repeatForever = false,
-      this.isRepeatingAnimation = true})
-      : assert(text != null, 'You must specify the list of text'),
+  TypewriterAnimatedTextKit({
+    Key key,
+    @required this.text,
+    this.textStyle,
+    this.speed = const Duration(milliseconds: 30),
+    this.pause = const Duration(milliseconds: 1000),
+    this.displayFullTextOnTap = false,
+    this.stopPauseOnTap = false,
+    this.onTap,
+    this.onNext,
+    this.onNextBeforePause,
+    this.onFinished,
+    this.totalRepeatCount = 3,
+    this.alignment = AlignmentDirectional.topStart,
+    this.textAlign = TextAlign.start,
+    this.repeatForever = false,
+    this.isRepeatingAnimation = true,
+  })  : assert(text != null, 'You must specify the list of text'),
+        assert(null != speed),
+        assert(null != pause),
+        assert(null != displayFullTextOnTap),
+        assert(null != stopPauseOnTap),
+        assert(null != totalRepeatCount),
+        assert(null != alignment),
+        assert(null != textAlign),
+        assert(null != repeatForever),
+        assert(null != isRepeatingAnimation),
         super(key: key);
 
   @override
@@ -103,12 +112,8 @@ class _TypewriterState extends State<TypewriterAnimatedTextKit>
   AnimationController _controller;
 
   Animation _typewriterText;
-  List<Widget> textWidgetList = [];
 
-  Duration _speed;
-  Duration _pause;
-
-  List<Map<String, dynamic>> _texts = [];
+  final _texts = <Map<String, dynamic>>[];
 
   int _index;
 
@@ -122,9 +127,6 @@ class _TypewriterState extends State<TypewriterAnimatedTextKit>
   void initState() {
     super.initState();
 
-    _speed = widget.speed ?? const Duration(milliseconds: 30);
-    _pause = widget.pause ?? const Duration(milliseconds: 1000);
-
     _index = -1;
 
     _currentRepeatCount = 0;
@@ -133,8 +135,8 @@ class _TypewriterState extends State<TypewriterAnimatedTextKit>
       _texts.add({
         'text': text,
         'chars': text.characters,
-        'speed': _speed,
-        'pause': _pause,
+        'speed': widget.speed,
+        'pause': widget.pause,
       });
     });
 
@@ -254,8 +256,7 @@ class _TypewriterState extends State<TypewriterAnimatedTextKit>
     if (mounted) setState(() {});
 
     // Handle onNextBeforePause callback
-    if (widget.onNextBeforePause != null)
-      widget.onNextBeforePause(_index, isLast);
+    widget.onNextBeforePause?.call(_index, isLast);
   }
 
   void _animationEndCallback(state) {

--- a/lib/src/wavy.dart
+++ b/lib/src/wavy.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 
 class WavyAnimatedTextKit extends StatefulWidget {
@@ -13,9 +12,13 @@ class WavyAnimatedTextKit extends StatefulWidget {
     this.onNextBeforePause,
     this.onFinished,
     this.isRepeatingAnimation = true,
-    this.speed,
-    this.pause,
-  }) : super(key: key);
+    this.speed = const Duration(milliseconds: 300),
+    this.pause = const Duration(milliseconds: 1000),
+  })  : assert(null != text),
+        assert(null != isRepeatingAnimation),
+        assert(null != speed),
+        assert(null != pause),
+        super(key: key);
 
   /// List of [String] that would be displayed subsequently in the animation.
   final List<String> text;
@@ -64,11 +67,9 @@ class _WavyAnimatedTextKitState extends State<WavyAnimatedTextKit>
     with TickerProviderStateMixin {
   // List<GlobalKey<_WTextState>> _keys;
 
-  Duration _speed;
-  Duration _pause;
-
   AnimationController _controller;
   Animation<double> _waveAnim;
+  Timer _timer;
 
   int _index = -1;
 
@@ -76,21 +77,21 @@ class _WavyAnimatedTextKitState extends State<WavyAnimatedTextKit>
   void initState() {
     super.initState();
 
-    _speed = widget.speed ?? const Duration(milliseconds: 300);
-    _pause = widget.pause ?? const Duration(milliseconds: 1000);
-
     _nextAnimation();
   }
 
   void _statusListener(status) {
     if (status == AnimationStatus.completed) {
       _setPause();
-      Timer(_pause, _nextAnimation);
+      assert(null == _timer || !_timer.isActive);
+      _timer = Timer(widget.pause, _nextAnimation);
     }
   }
 
   @override
   void dispose() {
+    _timer?.cancel();
+    _controller?.stop();
     _controller.dispose();
     super.dispose();
   }
@@ -141,9 +142,7 @@ class _WavyAnimatedTextKitState extends State<WavyAnimatedTextKit>
 
     _controller = AnimationController(
       vsync: this,
-      duration: Duration(
-        milliseconds: _speed.inMilliseconds * widget.text[_index].length,
-      ),
+      duration: widget.speed * widget.text[_index].length,
     )..addStatusListener(_statusListener);
 
     _waveAnim =


### PR DESCRIPTION
* Moved `_duration` and `_pause` defaults to the `StatefulWidget`.
* Added assertions to ensure proper usage.
* Removed unused `textWidgetList` variables.
* Reordered imports.
* Tweaked indention.
* Declared `_texts` final.
* Added `const` keywords.