### PR TITLE
Corrected alignment adjustment logic.

### DIFF
--- a/lib/src/rotate.dart
+++ b/lib/src/rotate.dart
@@ -45,8 +45,13 @@ class RotateAnimatedTextKit extends StatefulWidget {
 
   /// Adds [AlignmentGeometry] property to the text in the widget.
   ///
-  /// By default it is set to [AlignmentDirectional.topStart]
+  /// By default it is set to [Alignment.center]
   final AlignmentGeometry alignment;
+
+  /// Specifies the [TextDirection] for resolving alignment.
+  ///
+  /// By default it is set to [TextDirection.ltr]
+  final TextDirection textDirection;
 
   /// Adds [TextAlign] property to the text in the widget.
   ///
@@ -86,7 +91,8 @@ class RotateAnimatedTextKit extends StatefulWidget {
     this.totalRepeatCount = 3,
     this.duration = const Duration(milliseconds: 2000),
     this.onTap,
-    this.alignment = const Alignment(0.0, 0.0),
+    this.alignment = Alignment.center,
+    this.textDirection = TextDirection.ltr,
     this.textAlign = TextAlign.start,
     this.displayFullTextOnTap = false,
     this.repeatForever = false,
@@ -155,7 +161,10 @@ class _RotatingTextState extends State<RotateAnimatedTextKit>
     );
     return GestureDetector(
       onTap: _onTap,
-      child: SizedBox(
+      child: Container(
+        // Note that Transparent color is workaround for GestureDetector.onTap
+        // See https://github.com/flutter/flutter/issues/68986
+        color: Colors.transparent,
         height: _transitionHeight,
         child: _isCurrentlyPausing || !_controller.isAnimating
             ? textWidget
@@ -183,9 +192,11 @@ class _RotatingTextState extends State<RotateAnimatedTextKit>
       vsync: this,
     );
 
+    final direction = widget.textDirection;
+
     _slideIn = AlignmentTween(
-      begin: const Alignment(-1.0, -1.0) + widget.alignment,
-      end: const Alignment(-1.0, 0.0) + widget.alignment,
+      begin: Alignment.topLeft.add(widget.alignment).resolve(direction),
+      end: Alignment.centerLeft.add(widget.alignment).resolve(direction),
     ).animate(
       CurvedAnimation(
         parent: _controller,
@@ -201,8 +212,8 @@ class _RotatingTextState extends State<RotateAnimatedTextKit>
     );
 
     _slideOut = AlignmentTween(
-      begin: const Alignment(-1.0, 0.0) + widget.alignment,
-      end: const Alignment(-1.0, 1.0) + widget.alignment,
+      begin: Alignment.centerLeft.add(widget.alignment).resolve(direction),
+      end: Alignment.bottomLeft.add(widget.alignment).resolve(direction),
     ).animate(
       CurvedAnimation(
         parent: _controller,

--- a/test/smoke_test.dart
+++ b/test/smoke_test.dart
@@ -31,6 +31,8 @@ void main() {
     ];
     const textStyle = TextStyle(fontSize: 32.0, fontWeight: FontWeight.bold);
 
+    var tapped = false;
+
     final tapableWidgets = <Widget>[
       ColorizeAnimatedTextKit(
         text: tripleText,
@@ -41,7 +43,7 @@ void main() {
           Colors.green,
         ],
         onTap: () {
-          print(' > ColorizeAnimatedTextKit was tapped');
+          tapped = true;
         },
       ),
       FadeAnimatedTextKit(
@@ -49,7 +51,7 @@ void main() {
         textStyle: textStyle,
         displayFullTextOnTap: true,
         onTap: () {
-          print(' > FadeAnimatedTextKit was tapped');
+          tapped = true;
         },
       ),
       RotateAnimatedTextKit(
@@ -57,7 +59,7 @@ void main() {
         textStyle: textStyle,
         displayFullTextOnTap: true,
         onTap: () {
-          print(' > RotateAnimatedTextKit was tapped');
+          tapped = true;
         },
       ),
       ScaleAnimatedTextKit(
@@ -65,7 +67,7 @@ void main() {
         textStyle: textStyle,
         displayFullTextOnTap: true,
         onTap: () {
-          print(' > ScaleAnimatedTextKit was tapped');
+          tapped = true;
         },
       ),
       TyperAnimatedTextKit(
@@ -73,7 +75,7 @@ void main() {
         textStyle: textStyle,
         displayFullTextOnTap: true,
         onTap: () {
-          print(' > TyperAnimatedTextKit was tapped');
+          tapped = true;
         },
       ),
       TypewriterAnimatedTextKit(
@@ -81,17 +83,17 @@ void main() {
         textStyle: textStyle,
         displayFullTextOnTap: true,
         onTap: () {
-          print(' > TypewriterAnimatedTextKit was tapped');
+          tapped = true;
         },
       ),
     ];
 
     for (var widget in tapableWidgets) {
-      print('Testing ${widget.runtimeType}');
-
+      print('Tap Testing ${widget.runtimeType}');
+      tapped = false;
       await tester.pumpWidget(MaterialApp(home: widget));
       await tester.tap(find.byWidget(widget));
-      await tester.pumpAndSettle();
+      assert(tapped);
     }
 
     tester.verifyTickersWereDisposed();


### PR DESCRIPTION
One of my recent changes replaced the logic in `RotateAnimatedTextKit` to handle the `alignment` property. The new logic was revised to use the `+` operator, which assumed that `alignment` was an `Alignment`. However, it is actually an `AlignmentGeometry`, so the code was reverted to use the `add` method, which can accommodate `Alignment` or `AlignmentDirectional`. Ultimately, an `Alignment` is required by the `AlignmentTween`, so the `add` result needs to be _resolved_, which requires the `textDirection`. The final code is type safe.

* Added `textDirection` to `RotateAnimatedTextKit` which was necessary to accommodate an `AlignmentGeometry` override.
* Replaced `Alignment` constants with built-in constants making it easier to read and maintain.
* Added workaround for gesture detection taps, so was able to validate the `onTap` callback for `RotateAnimatedTextKit` and boost code coverage.
* Corrected an incorrect comment which erroneously stated the wrong default value.