### PR TITLE
Added a mounted guard before setState.

### DIFF
--- a/lib/src/scale.dart
+++ b/lib/src/scale.dart
@@ -239,7 +239,7 @@ class _ScaleTextState extends State<ScaleAnimatedTextKit>
       _index++;
     }
 
-    setState(() {});
+    if (mounted) setState(() {});
 
     _controller.forward(from: 0.0);
   }
@@ -248,7 +248,7 @@ class _ScaleTextState extends State<ScaleAnimatedTextKit>
     final isLast = _index == widget.text.length - 1;
 
     _isCurrentlyPausing = true;
-    setState(() {});
+    if (mounted) setState(() {});
 
     // Handle onNextBeforePause callback
     widget.onNextBeforePause?.call(_index, isLast);


### PR DESCRIPTION
Replaces PR #103 to correct an Unhandled Exception: setState() called after dispose() in ScaleAnimatedTextKit, reported by @asionbo.