### PR TITLE
Added missing dartdoc to classes

### DIFF
--- a/lib/animated_text_kit.dart
+++ b/lib/animated_text_kit.dart
@@ -1,3 +1,4 @@
+/// _Animated Text Kit_ is a library of some cool and awesome text animations.
 library animated_text_kit;
 
 export 'src/typer.dart';

--- a/lib/src/colorize.dart
+++ b/lib/src/colorize.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'dart:async';
 
+/// Animation that displays [text] elements, shimmering transition between [colors].
+///
+/// ![colorize example](https://raw.githubusercontent.com/aagarwal1012/Animated-Text-Kit/master/display/colorize.gif)
 class ColorizeAnimatedTextKit extends StatefulWidget {
   /// List of [String] that would be displayed subsequently in the animation.
   final List<String> text;

--- a/lib/src/colorize.dart
+++ b/lib/src/colorize.dart
@@ -91,6 +91,7 @@ class ColorizeAnimatedTextKit extends StatefulWidget {
         assert(null != isRepeatingAnimation),
         super(key: key);
 
+  /// Creates the mutable state for this widget. See [StatefulWidget.createState].
   @override
   _ColorizeTextState createState() => _ColorizeTextState();
 }

--- a/lib/src/fade.dart
+++ b/lib/src/fade.dart
@@ -107,6 +107,7 @@ class FadeAnimatedTextKit extends StatefulWidget {
         assert(null != isRepeatingAnimation),
         super(key: key);
 
+  /// Creates the mutable state for this widget. See [StatefulWidget.createState].
   @override
   _FadeTextState createState() => _FadeTextState();
 }

--- a/lib/src/fade.dart
+++ b/lib/src/fade.dart
@@ -2,6 +2,9 @@ import 'dart:async';
 import 'dart:math';
 import 'package:flutter/material.dart';
 
+/// Animation that displays [text] elements, fading them in and then out.
+///
+/// ![fade example](https://raw.githubusercontent.com/aagarwal1012/Animated-Text-Kit/master/display/fade.gif)
 class FadeAnimatedTextKit extends StatefulWidget {
   /// List of [String] that would be displayed subsequently in the animation.
   final List<String> text;

--- a/lib/src/rotate.dart
+++ b/lib/src/rotate.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 
+/// Animation that displays [text] elements, rotating them in one at a time.
+///
+/// ![rotate example](https://raw.githubusercontent.com/aagarwal1012/Animated-Text-Kit/master/display/rotate.gif)
 class RotateAnimatedTextKit extends StatefulWidget {
   /// List of [String] that would be displayed subsequently in the animation.
   final List<String> text;

--- a/lib/src/rotate.dart
+++ b/lib/src/rotate.dart
@@ -111,6 +111,7 @@ class RotateAnimatedTextKit extends StatefulWidget {
         assert(null != isRepeatingAnimation),
         super(key: key);
 
+  /// Creates the mutable state for this widget. See [StatefulWidget.createState].
   @override
   _RotatingTextState createState() => _RotatingTextState();
 }

--- a/lib/src/scale.dart
+++ b/lib/src/scale.dart
@@ -114,6 +114,7 @@ class ScaleAnimatedTextKit extends StatefulWidget {
         assert(null != stopPauseOnTap),
         super(key: key);
 
+  /// Creates the mutable state for this widget. See [StatefulWidget.createState].
   @override
   _ScaleTextState createState() => _ScaleTextState();
 }

--- a/lib/src/scale.dart
+++ b/lib/src/scale.dart
@@ -2,6 +2,9 @@ import 'dart:async';
 import 'dart:math';
 import 'package:flutter/material.dart';
 
+/// Animation that displays [text] elements, scaling them up and then out, one at a time.
+///
+/// ![scale example](https://raw.githubusercontent.com/aagarwal1012/Animated-Text-Kit/master/display/scale.gif)
 class ScaleAnimatedTextKit extends StatefulWidget {
   /// List of [String] that would be displayed subsequently in the animation.
   final List<String> text;

--- a/lib/src/text_liquid_fill.dart
+++ b/lib/src/text_liquid_fill.dart
@@ -72,6 +72,7 @@ class TextLiquidFill extends StatefulWidget {
         assert(null != waveColor),
         super(key: key);
 
+  /// Creates the mutable state for this widget. See [StatefulWidget.createState].
   @override
   _TextLiquidFillState createState() => _TextLiquidFillState();
 }

--- a/lib/src/text_liquid_fill.dart
+++ b/lib/src/text_liquid_fill.dart
@@ -1,6 +1,10 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
 
+/// Animation that displays a [text] element, coloring it to look like sloshing
+/// water is filling it up.
+///
+/// ![TextLiquidFill example](https://raw.githubusercontent.com/aagarwal1012/Animated-Text-Kit/master/display/text_liquid_fill.gif)
 class TextLiquidFill extends StatefulWidget {
   /// Gives [TextStyle] to the text string.
   ///
@@ -126,7 +130,7 @@ class _TextLiquidFillState extends State<TextLiquidFill>
             animation: _waveController,
             builder: (BuildContext context, Widget child) {
               return CustomPaint(
-                painter: WavePainter(
+                painter: _WavePainter(
                   textKey: _textKey,
                   waveAnimation: _waveController,
                   percentValue: _loadValue.value,
@@ -164,7 +168,7 @@ class _TextLiquidFillState extends State<TextLiquidFill>
   }
 }
 
-class WavePainter extends CustomPainter {
+class _WavePainter extends CustomPainter {
   final _pi2 = 2 * pi;
   final GlobalKey textKey;
   final Animation<double> waveAnimation;
@@ -172,7 +176,7 @@ class WavePainter extends CustomPainter {
   final double boxHeight;
   final Color waveColor;
 
-  WavePainter({
+  _WavePainter({
     @required this.textKey,
     this.waveAnimation,
     this.percentValue,

--- a/lib/src/typer.dart
+++ b/lib/src/typer.dart
@@ -92,6 +92,7 @@ class TyperAnimatedTextKit extends StatefulWidget {
         assert(null != stopPauseOnTap),
         super(key: key);
 
+  /// Creates the mutable state for this widget. See [StatefulWidget.createState].
   @override
   _TyperState createState() => _TyperState();
 }

--- a/lib/src/typer.dart
+++ b/lib/src/typer.dart
@@ -3,6 +3,10 @@ import 'dart:math';
 import 'package:characters/characters.dart';
 import 'package:flutter/material.dart';
 
+/// Animation that displays [text] elements, as if they are being typed one
+/// character at a time.
+///
+/// ![typer example](https://raw.githubusercontent.com/aagarwal1012/Animated-Text-Kit/master/display/typer.gif)
 class TyperAnimatedTextKit extends StatefulWidget {
   /// List of [String] that would be displayed subsequently in the animation.
   final List<String> text;

--- a/lib/src/typewriter.dart
+++ b/lib/src/typewriter.dart
@@ -107,6 +107,7 @@ class TypewriterAnimatedTextKit extends StatefulWidget {
         assert(null != isRepeatingAnimation),
         super(key: key);
 
+  /// Creates the mutable state for this widget. See [StatefulWidget.createState].
   @override
   _TypewriterState createState() => _TypewriterState();
 }

--- a/lib/src/typewriter.dart
+++ b/lib/src/typewriter.dart
@@ -3,6 +3,10 @@ import 'dart:math';
 import 'package:characters/characters.dart';
 import 'package:flutter/material.dart';
 
+/// Animation that displays [text] elements, as if they are being typed one
+/// character at a time. Similar to [TyperAnimatedTextKit], but shows a cursor.
+///
+/// ![typewriter example](https://raw.githubusercontent.com/aagarwal1012/Animated-Text-Kit/master/display/typewriter.gif)
 class TypewriterAnimatedTextKit extends StatefulWidget {
   /// List of [String] that would be displayed subsequently in the animation.
   final List<String> text;

--- a/lib/src/wavy.dart
+++ b/lib/src/wavy.dart
@@ -2,6 +2,10 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
 
+/// Animation that displays [text] elements, with each text animated with its
+/// characters popping like a stadium wave.
+///
+/// ![Wavy example](https://raw.githubusercontent.com/aagarwal1012/Animated-Text-Kit/master/display/wavy.gif)
 class WavyAnimatedTextKit extends StatefulWidget {
   const WavyAnimatedTextKit({
     Key key,

--- a/lib/src/wavy.dart
+++ b/lib/src/wavy.dart
@@ -63,14 +63,13 @@ class WavyAnimatedTextKit extends StatefulWidget {
   /// By default it is set to true.
   final bool isRepeatingAnimation;
 
+  /// Creates the mutable state for this widget. See [StatefulWidget.createState].
   @override
   _WavyAnimatedTextKitState createState() => _WavyAnimatedTextKitState();
 }
 
 class _WavyAnimatedTextKitState extends State<WavyAnimatedTextKit>
     with TickerProviderStateMixin {
-  // List<GlobalKey<_WTextState>> _keys;
-
   AnimationController _controller;
   Animation<double> _waveAnim;
   Timer _timer;


### PR DESCRIPTION
* Added missing dartdoc to classes.
* For _TextLiquidFill_, renamed `WavePainter`  to be `_WavePainter` since the class is internal only -- and then missing docs are not critical.
* Related to #147 