### PR TITLE
Removed License section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@
 - [Bugs or Requests](#bugs-or-requests)
 - [Donate](#donate)
 - [Contributors](#contributors)
-- [License](#license)
 
 # Installing
 
@@ -368,6 +367,3 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome! See [Contributing.md](https://github.com/aagarwal1012/Animated-Text-Kit/blob/master/CONTRIBUTING.md).
 
-# License
-
-Animated-Text-Kit is licensed under `MIT license`. View [license](https://github.com/aagarwal1012/Animated-Text-Kit/blob/master/LICENSE).


### PR DESCRIPTION
Removed the License section because it is redundant with the License badge, and both `GitHub` and `Pub.dev` list the License on a side panel.