### PR TITLE
Removed unused Alignment Geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.0
+
+- Removed the unused `alignment` property from all except `RotateAnimatedTextKit`.
+
 ## 2.5.4
 
 - Added missing dart documentation to the public classes and methods.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ SizedBox(
         fontWeight: FontWeight.bold
     ),
     textAlign: TextAlign.start,
-    alignment: AlignmentDirectional.topStart // or Alignment.topLeft
   ),
 );
 ```
@@ -190,7 +189,6 @@ SizedBox(
         fontFamily: "Bobbers"
     ),
     textAlign: TextAlign.start,
-    alignment: AlignmentDirectional.topStart // or Alignment.topLeft
   ),
 );
 ```
@@ -217,7 +215,6 @@ SizedBox(
         fontFamily: "Agne"
     ),
     textAlign: TextAlign.start,
-    alignment: AlignmentDirectional.topStart // or Alignment.topLeft
   ),
 );
 ```
@@ -243,7 +240,6 @@ SizedBox(
         fontFamily: "Canterbury"
     ),
     textAlign: TextAlign.start,
-    alignment: AlignmentDirectional.topStart // or Alignment.topLeft
   ),
 );
 ```
@@ -275,7 +271,6 @@ SizedBox(
       Colors.red,
     ],
     textAlign: TextAlign.start,
-    alignment: AlignmentDirectional.topStart // or Alignment.topLeft
   ),
 );
 ```
@@ -360,4 +355,3 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome! See [Contributing.md](https://github.com/aagarwal1012/Animated-Text-Kit/blob/master/CONTRIBUTING.md).
-

--- a/lib/src/colorize.dart
+++ b/lib/src/colorize.dart
@@ -34,11 +34,6 @@ class ColorizeAnimatedTextKit extends StatefulWidget {
   /// Will be called right before the next text, after the pause parameter
   final void Function(int, bool) onNext;
 
-  /// Adds [AlignmentGeometry] property to the text in the widget.
-  ///
-  /// By default it is set to [AlignmentDirectional.topStart]
-  final AlignmentGeometry alignment;
-
   /// Adds [TextAlign] property to the text in the widget.
   ///
   /// By default it is set to [TextAlign.start]
@@ -75,7 +70,6 @@ class ColorizeAnimatedTextKit extends StatefulWidget {
     this.onTap,
     this.onNext,
     this.onFinished,
-    this.alignment = AlignmentDirectional.topStart,
     this.textAlign = TextAlign.start,
     this.totalRepeatCount = 3,
     this.repeatForever = false,
@@ -84,7 +78,6 @@ class ColorizeAnimatedTextKit extends StatefulWidget {
         assert(null != colors && colors.length > 1),
         assert(null != speed),
         assert(null != pause),
-        assert(null != alignment),
         assert(null != textAlign),
         assert(null != totalRepeatCount),
         assert(null != repeatForever),

--- a/lib/src/fade.dart
+++ b/lib/src/fade.dart
@@ -42,11 +42,6 @@ class FadeAnimatedTextKit extends StatefulWidget {
   /// Will be called at the end of n-1 animation, before the pause parameter
   final void Function(int, bool) onNextBeforePause;
 
-  /// Adds [AlignmentGeometry] property to the text in the widget.
-  ///
-  /// By default it is set to [AlignmentDirectional.topStart]
-  final AlignmentGeometry alignment;
-
   /// Adds [TextAlign] property to the text in the widget.
   ///
   /// By default it is set to [TextAlign.start]
@@ -91,7 +86,6 @@ class FadeAnimatedTextKit extends StatefulWidget {
     this.onNextBeforePause,
     this.onFinished,
     this.totalRepeatCount = 3,
-    this.alignment = AlignmentDirectional.topStart,
     this.textAlign = TextAlign.start,
     this.repeatForever = false,
     this.isRepeatingAnimation = true,
@@ -101,7 +95,6 @@ class FadeAnimatedTextKit extends StatefulWidget {
         assert(null != displayFullTextOnTap),
         assert(null != stopPauseOnTap),
         assert(null != totalRepeatCount),
-        assert(null != alignment),
         assert(null != textAlign),
         assert(null != repeatForever),
         assert(null != isRepeatingAnimation),

--- a/lib/src/scale.dart
+++ b/lib/src/scale.dart
@@ -42,11 +42,6 @@ class ScaleAnimatedTextKit extends StatefulWidget {
   /// Will be called at the end of n-1 animation, before the pause parameter
   final void Function(int, bool) onNextBeforePause;
 
-  /// Adds [AlignmentGeometry] property to the text in the widget.
-  ///
-  /// By default it is set to [AlignmentDirectional.topStart]
-  final AlignmentGeometry alignment;
-
   /// Adds [TextAlign] property to the text in the widget.
   ///
   /// By default it is set to [TextAlign.start]
@@ -95,7 +90,6 @@ class ScaleAnimatedTextKit extends StatefulWidget {
     this.onNextBeforePause,
     this.onFinished,
     this.totalRepeatCount = 3,
-    this.alignment = AlignmentDirectional.topStart,
     this.textAlign = TextAlign.start,
     this.repeatForever = false,
     this.isRepeatingAnimation = true,
@@ -106,7 +100,6 @@ class ScaleAnimatedTextKit extends StatefulWidget {
         assert(null != pause),
         assert(null != duration),
         assert(null != totalRepeatCount),
-        assert(null != alignment),
         assert(null != textAlign),
         assert(null != repeatForever),
         assert(null != isRepeatingAnimation),

--- a/lib/src/typer.dart
+++ b/lib/src/typer.dart
@@ -42,11 +42,6 @@ class TyperAnimatedTextKit extends StatefulWidget {
   /// Will be called at the end of n-1 animation, before the pause parameter
   final void Function(int, bool) onNextBeforePause;
 
-  /// Adds [AlignmentGeometry] property to the text in the widget.
-  ///
-  /// By default it is set to [AlignmentDirectional.topStart]
-  final AlignmentGeometry alignment;
-
   /// Adds [TextAlign] property to the text in the widget.
   ///
   /// By default it is set to [TextAlign.start]
@@ -75,7 +70,6 @@ class TyperAnimatedTextKit extends StatefulWidget {
     this.onNext,
     this.onNextBeforePause,
     this.onFinished,
-    this.alignment = AlignmentDirectional.topStart,
     this.textAlign = TextAlign.start,
     this.isRepeatingAnimation = true,
     this.speed = const Duration(milliseconds: 40),
@@ -83,7 +77,6 @@ class TyperAnimatedTextKit extends StatefulWidget {
     this.displayFullTextOnTap = false,
     this.stopPauseOnTap = false,
   })  : assert(null != text),
-        assert(null != alignment),
         assert(null != textAlign),
         assert(null != isRepeatingAnimation),
         assert(null != speed),

--- a/lib/src/typewriter.dart
+++ b/lib/src/typewriter.dart
@@ -42,11 +42,6 @@ class TypewriterAnimatedTextKit extends StatefulWidget {
   /// Will be called at the end of n-1 animation, before the pause parameter
   final void Function(int, bool) onNextBeforePause;
 
-  /// Adds [AlignmentGeometry] property to the text in the widget.
-  ///
-  /// By default it is set to [AlignmentDirectional.topStart]
-  final AlignmentGeometry alignment;
-
   /// Adds [TextAlign] property to the text in the widget.
   ///
   /// By default it is set to [TextAlign.start]
@@ -91,7 +86,6 @@ class TypewriterAnimatedTextKit extends StatefulWidget {
     this.onNextBeforePause,
     this.onFinished,
     this.totalRepeatCount = 3,
-    this.alignment = AlignmentDirectional.topStart,
     this.textAlign = TextAlign.start,
     this.repeatForever = false,
     this.isRepeatingAnimation = true,
@@ -101,7 +95,6 @@ class TypewriterAnimatedTextKit extends StatefulWidget {
         assert(null != displayFullTextOnTap),
         assert(null != stopPauseOnTap),
         assert(null != totalRepeatCount),
-        assert(null != alignment),
         assert(null != textAlign),
         assert(null != repeatForever),
         assert(null != isRepeatingAnimation),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: animated_text_kit
 description: A flutter package project which contains a collection of cool and beautiful text animations.
-version: 2.5.4
+version: 2.6.0
 homepage: https://github.com/aagarwal1012/Animated-Text-Kit/
 maintainer: Ayush Agarwal (@aagarwal1012)
 


### PR DESCRIPTION
Removed unused `alignment` property from all _animated text_ classes except `RotateAnimatedTextKit`.