### PR TITLE
Adjusted the Dart sdk constraint.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,5 +17,5 @@ dev_dependencies:
 flutter:
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"
   flutter: ">=0.3.0 <2.0.0"


### PR DESCRIPTION
Travis CI builds for **Beta** and **Dev** were failing:
> You should edit `pubspec.yaml` to contain an SDK constraint:
```yaml
environment:
  sdk: '>=2.10.0 <3.0.0'
```
> See https://dart.dev/go/sdk-constraint

Since the package does use [extension methods](https://dart.dev/guides/language/extension-methods), Dart 2.7 is required.  However, we are only testing Dart 2.10+ with CI, so made that the constraint for now.