### PR TITLE
GitHub actions 3 - Optimization tweaks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run Tests
         run: |
           flutter pub get
-          flutter format --set-exit-if-changed .
+          flutter format --dry-run --set-exit-if-changed .
           flutter analyze --no-pub
           flutter test --no-pub --coverage
       - name: Upload coverage to Codecov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           flutter pub get
           flutter format --set-exit-if-changed .
-          flutter analyze
+          flutter analyze --no-pub
           flutter test --no-pub --coverage
       - name: Upload coverage to Codecov
         if: ${{ matrix.channel == 'stable' }}


### PR DESCRIPTION
* Added `--dry-run` switch to `flutter format` because CI is only interested in _detecting_ a format issue, not actually fixing it.
* Added `--no-pub` switch to `flutter analyze` to avoid a redundant `pub get` (just like for `flutter test`).  It saves about a second.