### PR TITLE
Optimized the dispose for AnimatedTextKit.

### DIFF
--- a/lib/src/animated_text.dart
+++ b/lib/src/animated_text.dart
@@ -165,8 +165,7 @@ class _AnimatedTextKitState extends State<AnimatedTextKit>
   @override
   void dispose() {
     _timer?.cancel();
-    _controller?.stop();
-    _controller?.dispose();
+    _controller.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
* Removed the redundant call to `stop`, as well as redundant null-guards.