### PR TITLE
Fix: onNext callback has a void return type, and is not a VoidCallback.

### DIFF
--- a/lib/src/animated_text.dart
+++ b/lib/src/animated_text.dart
@@ -89,12 +89,12 @@ class AnimatedTextKit extends StatefulWidget {
   /// This method will run only if [isRepeatingAnimation] is set to false.
   final VoidCallback onFinished;
 
-  /// Adds the onNext [VoidCallback] to the animated widget.
+  /// Adds the onNext callback to the animated widget.
   ///
   /// Will be called right before the next text, after the pause parameter
   final void Function(int, bool) onNext;
 
-  /// Adds the onNextBeforePause [VoidCallback] to the animated widget.
+  /// Adds the onNextBeforePause callback to the animated widget.
   ///
   /// Will be called at the end of n-1 animation, before the pause parameter
   final void Function(int, bool) onNextBeforePause;

--- a/lib/src/colorize.dart
+++ b/lib/src/colorize.dart
@@ -123,7 +123,7 @@ class ColorizeAnimatedTextKit extends AnimatedTextKit {
     Duration speed = const Duration(milliseconds: 200),
     Duration pause = const Duration(milliseconds: 1000),
     VoidCallback onTap,
-    Function(int, bool) onNext,
+    void Function(int, bool) onNext,
     void Function(int, bool) onNextBeforePause,
     VoidCallback onFinished,
     bool isRepeatingAnimation = true,

--- a/lib/src/fade.dart
+++ b/lib/src/fade.dart
@@ -60,7 +60,7 @@ class FadeAnimatedTextKit extends AnimatedTextKit {
     Duration duration = const Duration(milliseconds: 2000),
     Duration pause = const Duration(milliseconds: 500),
     VoidCallback onTap,
-    Function(int, bool) onNext,
+    void Function(int, bool) onNext,
     void Function(int, bool) onNextBeforePause,
     VoidCallback onFinished,
     bool isRepeatingAnimation = true,

--- a/lib/src/rotate.dart
+++ b/lib/src/rotate.dart
@@ -116,7 +116,7 @@ class RotateAnimatedTextKit extends AnimatedTextKit {
     Duration duration = const Duration(milliseconds: 2000),
     Duration pause = const Duration(milliseconds: 500),
     VoidCallback onTap,
-    Function(int, bool) onNext,
+    void Function(int, bool) onNext,
     void Function(int, bool) onNextBeforePause,
     VoidCallback onFinished,
     bool isRepeatingAnimation = true,

--- a/lib/src/scale.dart
+++ b/lib/src/scale.dart
@@ -84,7 +84,7 @@ class ScaleAnimatedTextKit extends AnimatedTextKit {
     Duration duration = const Duration(milliseconds: 2000),
     Duration pause = const Duration(milliseconds: 500),
     VoidCallback onTap,
-    Function(int, bool) onNext,
+    void Function(int, bool) onNext,
     void Function(int, bool) onNextBeforePause,
     VoidCallback onFinished,
     bool isRepeatingAnimation = true,

--- a/lib/src/typer.dart
+++ b/lib/src/typer.dart
@@ -62,7 +62,7 @@ class TyperAnimatedTextKit extends AnimatedTextKit {
     bool displayFullTextOnTap = false,
     bool stopPauseOnTap = false,
     VoidCallback onTap,
-    Function(int, bool) onNext,
+    void Function(int, bool) onNext,
     void Function(int, bool) onNextBeforePause,
     VoidCallback onFinished,
     bool isRepeatingAnimation = true,

--- a/lib/src/typewriter.dart
+++ b/lib/src/typewriter.dart
@@ -108,7 +108,7 @@ class TypewriterAnimatedTextKit extends AnimatedTextKit {
     bool displayFullTextOnTap = false,
     bool stopPauseOnTap = false,
     VoidCallback onTap,
-    Function(int, bool) onNext,
+    void Function(int, bool) onNext,
     void Function(int, bool) onNextBeforePause,
     VoidCallback onFinished,
     bool isRepeatingAnimation = true,

--- a/lib/src/wavy.dart
+++ b/lib/src/wavy.dart
@@ -61,7 +61,7 @@ class WavyAnimatedTextKit extends AnimatedTextKit {
     Duration speed = const Duration(milliseconds: 300),
     Duration pause = const Duration(milliseconds: 1000),
     VoidCallback onTap,
-    Function(int, bool) onNext,
+    void Function(int, bool) onNext,
     void Function(int, bool) onNextBeforePause,
     VoidCallback onFinished,
     bool isRepeatingAnimation = true,


### PR DESCRIPTION
* Added missing return type to `onNext` parameters
* Fixed API documentation that erroneously labeled `onNext` and `onNextBeforePause` as `VoidCallback`, which they are not because they have parameters