### PR TITLE
Added option to disable rotate out to the RotateAnimatedText.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -258,25 +258,33 @@ List<AnimatedTextExample> animatedTextExamples({VoidCallback onTap}) =>
         child: AnimatedTextKit(
           onTap: onTap,
           animatedTexts: [
+            WavyAnimatedText(
+              'On Your Marks',
+              textStyle: const TextStyle(
+                fontSize: 24.0,
+              ),
+            ),
             FadeAnimatedText(
-              'Fade First',
+              'Get Set',
               textStyle: const TextStyle(
                 fontSize: 32.0,
                 fontWeight: FontWeight.bold,
               ),
             ),
             ScaleAnimatedText(
-              'Then Scale',
+              'Ready',
               textStyle: const TextStyle(
                 fontSize: 48.0,
                 fontWeight: FontWeight.bold,
               ),
             ),
-            WavyAnimatedText(
-              'Awesome',
+            RotateAnimatedText(
+              'Go!',
               textStyle: const TextStyle(
-                fontSize: 48.0,
+                fontSize: 64.0,
               ),
+              rotateOut: false,
+              duration: const Duration(milliseconds: 400),
             )
           ],
         ),


### PR DESCRIPTION
* Added a `rotateOut` flag to `RotateAnimatedText` so that you can optionally disable the rotate-out.  Resolves #175
* Replaced the _left_ alignment bias in `RotateAnimatedText` to be _center_ instead.  Resolves #179
* Revised the _Combination_ example to demonstrate the _rotate-in_ capability.