### PR TITLE
Added option to specify curves in TyperAnimatedText and TypewriterAnimatedText

### DIFF
--- a/lib/src/typer.dart
+++ b/lib/src/typer.dart
@@ -14,7 +14,7 @@ class TyperAnimatedText extends AnimatedText {
 
   /// The [Curve] of the rate of change of animation over time.
   ///
-  /// By default it is set to Curves.ease.
+  /// By default it is set to Curves.linear.
   final Curve curve;
 
   TyperAnimatedText(
@@ -22,8 +22,9 @@ class TyperAnimatedText extends AnimatedText {
     TextAlign textAlign = TextAlign.start,
     @required TextStyle textStyle,
     this.speed = const Duration(milliseconds: 40),
-    this.curve = Curves.ease,
+    this.curve = Curves.linear,
   })  : assert(null != speed),
+        assert(null != curve),
         super(
           text: text,
           textAlign: textAlign,
@@ -48,14 +49,8 @@ class TyperAnimatedText extends AnimatedText {
   Widget animatedBuilder(BuildContext context, Widget child) {
     /// Output of CurveTween is in the range [0, 1] for majority of the curves.
     /// It is converted to [0, textCharacters.length].
-    var count = (_typingText.value * textCharacters.length).round();
-
-    if (count < 0) {
-      count = 0;
-    }
-    if (count >= textCharacters.length) {
-      count = textCharacters.length - 1;
-    }
+    final count =
+        (_typingText.value.clamp(0, 1) * textCharacters.length).round();
 
     assert(count <= textCharacters.length);
     return textWidget(textCharacters.take(count).toString());
@@ -83,7 +78,7 @@ class TyperAnimatedTextKit extends AnimatedTextKit {
     bool isRepeatingAnimation = true,
     bool repeatForever = true,
     int totalRepeatCount = 3,
-    Curve curve = Curves.ease,
+    Curve curve = Curves.linear,
   }) : super(
           key: key,
           animatedTexts:

--- a/lib/src/typewriter.dart
+++ b/lib/src/typewriter.dart
@@ -17,7 +17,7 @@ class TypewriterAnimatedText extends AnimatedText {
 
   /// The [Curve] of the rate of change of animation over time.
   ///
-  /// By default it is set to Curves.ease.
+  /// By default it is set to Curves.linear.
   final Curve curve;
 
   TypewriterAnimatedText(
@@ -25,8 +25,9 @@ class TypewriterAnimatedText extends AnimatedText {
     TextAlign textAlign = TextAlign.start,
     @required TextStyle textStyle,
     this.speed = const Duration(milliseconds: 30),
-    this.curve = Curves.ease,
+    this.curve = Curves.linear,
   })  : assert(null != speed),
+        assert(null != curve),
         super(
           text: text,
           textAlign: textAlign,
@@ -67,17 +68,11 @@ class TypewriterAnimatedText extends AnimatedText {
   @override
   Widget animatedBuilder(BuildContext context, Widget child) {
     /// Output of CurveTween is in the range [0, 1] for majority of the curves.
-    /// It is converted to [0, textCharacters.length].
+    /// It is converted to [0, textCharacters.length + extraLengthForBlinks].
     final textLen = textCharacters.length;
-    var typewriterValue =
-        (_typewriterText.value * textCharacters.length).round();
-
-    if (typewriterValue < 0) {
-      typewriterValue = 0;
-    }
-    if (typewriterValue >= textCharacters.length) {
-      typewriterValue = textCharacters.length - 1;
-    }
+    final typewriterValue = (_typewriterText.value.clamp(0, 1) *
+            (textCharacters.length + extraLengthForBlinks))
+        .round();
 
     var visibleString = text;
     var suffixColor = Colors.transparent;
@@ -129,7 +124,7 @@ class TypewriterAnimatedTextKit extends AnimatedTextKit {
     bool isRepeatingAnimation = true,
     bool repeatForever = true,
     int totalRepeatCount = 3,
-    Curve curve = Curves.ease,
+    Curve curve = Curves.linear,
   }) : super(
           key: key,
           animatedTexts:


### PR DESCRIPTION
Pull request to  issue #100.

I have added `curve` property to both `TyperAnimatedText` and `TypewriterAnimatedText`.

### Usage
1. TyperAnimatedTextKit
```diff
TyperAnimatedTextKit(
  onTap: () {
      print("Tap Event");
    },
  text: [
    "It is not enough to do your best,",
    "you must know what to do,",
    "and then do your best",
    "- W.Edwards Deming",
  ],
  textStyle: TextStyle(
      fontSize: 30.0,
      fontFamily: "Bobbers"
  ),
  textAlign: TextAlign.start,
  alignment: AlignmentDirectional.topStart,
+ curve: Curves.bounceIn,
);
```

2. TypewriterAnimatedTextKit
```diff
TypewriterAnimatedTextKit(
  onTap: () {
      print("Tap Event");
    },
  text: [
    "Discipline is the best tool",
    "Design first, then code",
    "Do not patch bugs out, rewrite them",
    "Do not test bugs out, design them out",
  ],
  textStyle: TextStyle(
      fontSize: 30.0,
      fontFamily: "Agne"
  ),
  textAlign: TextAlign.start,
+ curve: Curves.bounceIn,
);
```

### Ouput 
Example output with `Curves.bounceIn`. I've lowered the speed a bit to comprehend the effect.

![TypewriterAnimatedKit](https://user-images.githubusercontent.com/35297280/103507180-922cef00-4e84-11eb-97d8-6a3f387220fc.GIF)


### Changes

Defined a curve property in `TyperAnimatedText` and `TypewriterAnimatedText` classes.
```diff
  + /// The [Curve] of the rate of change of animation over time.
  + ///
  + /// By default it is set to Curves.ease.
  + final Curve curve;
```

Applied `CurveTween` instead of `StepTween` on `count` in `TyperwriterAnimatedTextKit`. `CurveTween` by default lies in the range of `[0, 1]` for most curves apart from a few exceptions (Refer the adjoining figure).

![a](https://user-images.githubusercontent.com/35297280/103508450-0072b100-4e87-11eb-94ae-3875df786067.jpg)

```diff
- Animation<int> _typingText;
+ Animation<double> _typingText;
```
```diff
- _typingText = StepTween(
- begin: 0,
- end: textCharacters.length,
+ _typingText = CurveTween(
+ curve: curve,
).animate(controller);
```

The value is converted to range `[0, length - 1]` by first multiplying `[0, 1]` by the total length and rounding it to nearest integer. The values lying outside the output range is clipped.
```diff
- final count = _typingText.value;
+ /// Output of CurveTween is in the range [0, 1] for majority of the curves.
+ /// It is converted to [0, textCharacters.length].
+ var count = (_typingText.value * textCharacters.length).round();
+ 
+ if (count < 0) {
+   count = 0;
+ }
+ if (count >= textCharacters.length) {
+   count = textCharacters.length - 1;
+ }
```
Similar changes were done to `TyperAnimationTextKit`.
