### PR TITLE
ptch: Add fadeInEnd and fadeOutBegin to test

### DIFF
--- a/test/smoke_test.dart
+++ b/test/smoke_test.dart
@@ -33,6 +33,8 @@ void main() {
     const textStyle = TextStyle(fontSize: 32.0, fontWeight: FontWeight.bold);
 
     var tapped = false;
+    var fadeInEnd = 0.5;
+    var fadeOutBegin = 0.8;
 
     final tapableWidgets = <Widget>[
       ColorizeAnimatedTextKit(
@@ -51,6 +53,8 @@ void main() {
         text: tripleText,
         textStyle: textStyle,
         displayFullTextOnTap: true,
+        fadeInEnd: fadeInEnd,
+        fadeOutBegin: fadeOutBegin,
         onTap: () {
           tapped = true;
         },


### PR DESCRIPTION
## Description
Add the fadeInEnd and fadeOutBegin arguments to the FadeAnimatedTextKit widget in the test.

## Issues
Fix #210.

## Pull Request Process

1. Ensure any install or build dependencies are removed before the end of the layer when doing a build.
2. Update the README.md if needed with details of changes to the interface, this includes new environment variables, exposed ports, useful file locations and container parameters.
3. Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
4. You may merge the Pull Request in once you have the sign-off of one developer, or if you do not have permission to do that, you may request the second reviewer to merge it for you.