### PR TITLE
textStyle property is no longer required for AnimatedText subclasses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
+## 4.1.0
+
+- Legacy `Kit` classes are now marked as _deprecated_
+- `DefaultTextStyle` may be used to set a common text style across `AnimatedText` instances
+- `textStyle` is no longer _required_ for `AnimatedText` subclasses (except for `ColorizeAnimatedText`)
+- **BREAKING CHANGE**: `AnimatedText.completeText` now has a `BuildContext` parameter
+
 ## 4.0.0
 
 - Migrated to nnbd(null-safety)
 
 ## 3.1.2
+
 - Fixed insecure links in readme.
 
 ## 3.1.1
+
 - Added Flutter Favorite badge to readme.
 
 ## 3.1.0

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Add this to your package's `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  animated_text_kit: ^3.1.2
+  animated_text_kit: ^4.1.0
 ```
 
 ### 2. Install it
@@ -198,11 +198,6 @@ Many animations are provided, but you can also [create your own animations](#cre
 <img src="https://github.com/aagarwal1012/Animated-Text-Kit/blob/master/display/rotate.gif?raw=true" align = "right" height = "300px">
 
 ```dart
-const rotateTextStyle = TextStyle(
-  fontSize: 40.0,
-  fontFamily: 'Horizon',
-);
-
 Row(
   mainAxisSize: MainAxisSize.min,
   children: <Widget>[
@@ -212,24 +207,21 @@ Row(
       style: TextStyle(fontSize: 43.0),
     ),
     const SizedBox(width: 20.0, height: 100.0),
-    AnimatedTextKit(
-      animatedTexts: [
-        RotateAnimatedText(
-          'AWESOME',
-          textStyle: rotateTextStyle,
-        ),
-        RotateAnimatedText(
-          'OPTIMISTIC',
-          textStyle: rotateTextStyle,
-        ),
-        RotateAnimatedText(
-          'DIFFERENT',
-          textStyle: rotateTextStyle,
-        ),
-      ]
-      onTap: () {
-        print("Tap Event");
-      },
+    DefaultTextStyle(
+      style: const TextStyle(
+        fontSize: 40.0,
+        fontFamily: 'Horizon',
+      ),
+      child: AnimatedTextKit(
+        animatedTexts: [
+          RotateAnimatedText('AWESOME'),
+          RotateAnimatedText('OPTIMISTIC'),
+          RotateAnimatedText('DIFFERENT'),
+        ]
+        onTap: () {
+          print("Tap Event");
+        },
+      ),
     ),
   ],
 );
@@ -242,31 +234,23 @@ Row(
 <img src="https://github.com/aagarwal1012/Animated-Text-Kit/blob/master/display/fade.gif?raw=true" align = "right" height = "300px">
 
 ```dart
-const fadeTextStyle = TextStyle(
-  fontSize: 32.0,
-  fontWeight: FontWeight.bold,
-);
-
 return SizedBox(
   width: 250.0,
-  child: AnimatedTextKit(
-    animatedTexts: [
-      FadeAnimatedText(
-        'do IT!',
-        textStyle: fadeTextStyle,
-      ),
-      FadeAnimatedText(
-        'do it RIGHT!!',
-        textStyle: fadeTextStyle,
-      ),
-      FadeAnimatedText(
-        'do it RIGHT NOW!!!',
-        textStyle: fadeTextStyle,
-      ),
-    ],
-    onTap: () {
-      print("Tap Event");
-    },
+  child: DefaultTextStyle(
+    style: const TextStyle(
+      fontSize: 32.0,
+      fontWeight: FontWeight.bold,
+    ),
+    child: AnimatedTextKit(
+      animatedTexts: [
+        FadeAnimatedText('do IT!'),
+        FadeAnimatedText('do it RIGHT!!'),
+        FadeAnimatedText('do it RIGHT NOW!!!'),
+      ],
+      onTap: () {
+        print("Tap Event");
+      },
+    ),
   ),
 );
 ```
@@ -276,35 +260,24 @@ return SizedBox(
 <img src="https://github.com/aagarwal1012/Animated-Text-Kit/blob/master/display/typer.gif?raw=true" align = "right" height = "300px">
 
 ```dart
-const typerTextStyle = TextStyle(
-  fontSize: 30.0,
-  fontFamily: 'Bobbers',
-);
-
 return SizedBox(
   width: 250.0,
-  child: AnimatedTextKit(
-    animatedTexts: [
-      TyperAnimatedTextKit(
-        'It is not enough to do your best,',
-        textStyle: typerTextStyle,
-      ),
-      TyperAnimatedTextKit(
-        'you must know what to do,',
-        textStyle: typerTextStyle,
-      ),
-      TyperAnimatedTextKit(
-        'and then do your best',
-        textStyle: typerTextStyle,
-      ),
-      TyperAnimatedTextKit(
-        '- W.Edwards Deming',
-        textStyle: typerTextStyle,
-      ),
-    ]
-    onTap: () {
-      print("Tap Event");
-    },
+  child: DefaultTextStyle(
+    style: const TextStyle(
+      fontSize: 30.0,
+      fontFamily: 'Bobbers',
+    ),
+    child: AnimatedTextKit(
+      animatedTexts: [
+        TyperAnimatedText('It is not enough to do your best,'),
+        TyperAnimatedText('you must know what to do,'),
+        TyperAnimatedText('and then do your best'),
+        TyperAnimatedText('- W.Edwards Deming'),
+      ]
+      onTap: () {
+        print("Tap Event");
+      },
+    ),
   ),
 );
 ```
@@ -314,35 +287,24 @@ return SizedBox(
 <img src="https://github.com/aagarwal1012/Animated-Text-Kit/blob/master/display/typewriter.gif?raw=true" align = "right" height = "300px">
 
 ```dart
-const typewriterTextStyle = TextStyle(
-  fontSize: 30.0,
-  fontFamily: 'Agne',
-);
-
 return SizedBox(
   width: 250.0,
-  child: AnimatedTextKit(
-    animatedTexts: [
-      TypewriterAnimatedText(
-        'Discipline is the best tool',
-        textStyle: typewriterTextStyle,
-      ),
-      TypewriterAnimatedText(
-        'Design first, then code',
-        textStyle: typewriterTextStyle,
-      ),
-      TypewriterAnimatedText(
-        'Do not patch bugs out, rewrite them',
-        textStyle: typewriterTextStyle,
-      ),
-      TypewriterAnimatedText(
-        'Do not test bugs out, design them out',
-        textStyle: typewriterTextStyle,
-      ),
-    ],
-    onTap: () {
-      print("Tap Event");
-    },
+  child: DefaultTextStyle(
+    style: const TextStyle(
+      fontSize: 30.0,
+      fontFamily: 'Agne',
+    ),
+    child: AnimatedTextKit(
+      animatedTexts: [
+        TypewriterAnimatedText('Discipline is the best tool'),
+        TypewriterAnimatedText('Design first, then code'),
+        TypewriterAnimatedText('Do not patch bugs out, rewrite them'),
+        TypewriterAnimatedText('Do not test bugs out, design them out'),
+      ],
+      onTap: () {
+        print("Tap Event");
+      },
+    ),
   ),
 );
 ```
@@ -352,31 +314,23 @@ return SizedBox(
 <img src="https://github.com/aagarwal1012/Animated-Text-Kit/blob/master/display/scale.gif?raw=true" align = "right" height = "300px">
 
 ```dart
-const scaleTextStyle = TextStyle(
-  fontSize: 70.0,
-  fontFamily: 'Canterbury',
-);
-
 return SizedBox(
   width: 250.0,
-  child: AnimatedTextKit(
-    animatedTexts: [
-      ScaleAnimatedText(
-        'Think',
-        textStyle: scaleTextStyle,
-      ),
-      ScaleAnimatedText(
-        'Build',
-        textStyle: scaleTextStyle,
-      ),
-      ScaleAnimatedText(
-        'Ship',
-        textStyle: scaleTextStyle,
-      ),
-    ],
-    onTap: () {
-      print("Tap Event");
-    },
+  child: DefaultTextStyle(
+    style: const TextStyle(
+      fontSize: 70.0,
+      fontFamily: 'Canterbury',
+    ),
+    child: AnimatedTextKit(
+      animatedTexts: [
+        ScaleAnimatedText('Think'),
+        ScaleAnimatedText('Build'),
+        ScaleAnimatedText('Ship'),
+      ],
+      onTap: () {
+        print("Tap Event");
+      },
+    ),
   ),
 );
 ```
@@ -436,14 +390,14 @@ return SizedBox(
 return SizedBox(
   width: 250.0,
   child: TextLiquidFill(
-        text: 'LIQUIDY',
-        waveColor: Colors.blueAccent,
-        boxBackgroundColor: Colors.redAccent,
-        textStyle: TextStyle(
-          fontSize: 80.0,
-          fontWeight: FontWeight.bold,
-        ),
-        boxHeight: 300.0,
+    text: 'LIQUIDY',
+    waveColor: Colors.blueAccent,
+    boxBackgroundColor: Colors.redAccent,
+    textStyle: TextStyle(
+      fontSize: 80.0,
+      fontWeight: FontWeight.bold,
+    ),
+    boxHeight: 300.0,
   ),
 );
 ```
@@ -455,23 +409,20 @@ To get more information about how the animated text made from scratch by @HemilP
 <img src="https://github.com/aagarwal1012/Animated-Text-Kit/blob/master/display/wavy.gif?raw=true" align = "right" height = "300px">
 
 ```dart
-const wavyTextStyle = TextStyle(
-  fontSize: 32.0,
-  fontWeight: FontWeight.bold,
-);
-
-return AnimatedTextKit(
-  animatedTexts: [
-    WavyAnimatedText(
-      'Hello World',
-      textStyle: wavyTextStyle,
-    ),
-    WavyAnimatedText(
-      'Look at the waves',
-      textStyle: wavyTextStyle,
-    ),
-  ],
-  isRepeatingAnimation: true,
+return DefaultTextStyle(
+  style: const TextStyle(
+    fontSize: 20.0,
+  ),
+  child: AnimatedTextKit(
+    animatedTexts: [
+      WavyAnimatedText('Hello World'),
+      WavyAnimatedText('Look at the waves'),
+    ],
+    isRepeatingAnimation: true,
+    onTap: () {
+      print("Tap Event");
+    },
+  ),
 );
 ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -105,38 +105,8 @@ class AnimatedTextExample {
   });
 }
 
-// Rotate Text Style
-const _textStyleHorizon40 = TextStyle(
-  fontSize: 40.0,
-  fontFamily: 'Horizon',
-);
-
-// Fade Text Style
-const _textStyleBold32 = TextStyle(
-  fontSize: 32.0,
-  fontWeight: FontWeight.bold,
-);
-
-// Typer Text Style
-const _textStyleBobbers30 = TextStyle(
-  fontSize: 30.0,
-  fontFamily: 'Bobbers',
-);
-
-// Typewriter Text Style
-const _textStyleAgne30 = TextStyle(
-  fontSize: 30.0,
-  fontFamily: 'Agne',
-);
-
-// Scale Text Style
-const _textStyleCanterbury70 = TextStyle(
-  fontSize: 70.0,
-  fontFamily: 'Canterbury',
-);
-
 // Colorize Text Style
-const _textStyleHorizon50 = TextStyle(
+const _colorizeTextStyle = TextStyle(
   fontSize: 50.0,
   fontFamily: 'Horizon',
 );
@@ -148,9 +118,6 @@ const _colorizeColors = [
   Colors.yellow,
   Colors.red,
 ];
-
-// Wavy Text Style
-const _textStyleDefault20 = TextStyle(fontSize: 20);
 
 List<AnimatedTextExample> animatedTextExamples({VoidCallback? onTap}) =>
     <AnimatedTextExample>[
@@ -175,24 +142,26 @@ List<AnimatedTextExample> animatedTextExamples({VoidCallback? onTap}) =>
                   width: 20.0,
                   height: 100.0,
                 ),
-                AnimatedTextKit(
-                  animatedTexts: [
-                    RotateAnimatedText(
-                      'AWESOME',
-                      textStyle: _textStyleHorizon40,
-                    ),
-                    RotateAnimatedText(
-                      'OPTIMISTIC',
-                      textStyle: _textStyleHorizon40,
-                    ),
-                    RotateAnimatedText(
-                      'DIFFERENT',
-                      textStyle: _textStyleHorizon40,
-                    ),
-                  ],
-                  onTap: onTap,
-                  isRepeatingAnimation: true,
-                  totalRepeatCount: 10,
+                DefaultTextStyle(
+                  style: TextStyle(
+                    fontSize: 40.0,
+                    fontFamily: 'Horizon',
+                  ),
+                  child: AnimatedTextKit(
+                    animatedTexts: [
+                      RotateAnimatedText('AWESOME'),
+                      RotateAnimatedText('OPTIMISTIC'),
+                      RotateAnimatedText(
+                        'DIFFERENT',
+                        textStyle: const TextStyle(
+                          decoration: TextDecoration.underline,
+                        ),
+                      ),
+                    ],
+                    onTap: onTap,
+                    isRepeatingAnimation: true,
+                    totalRepeatCount: 10,
+                  ),
                 ),
               ],
             ),
@@ -202,22 +171,19 @@ List<AnimatedTextExample> animatedTextExamples({VoidCallback? onTap}) =>
       AnimatedTextExample(
         label: 'Fade',
         color: Colors.brown[600],
-        child: AnimatedTextKit(
-          animatedTexts: [
-            FadeAnimatedText(
-              'do IT!',
-              textStyle: _textStyleBold32,
-            ),
-            FadeAnimatedText(
-              'do it RIGHT!!',
-              textStyle: _textStyleBold32,
-            ),
-            FadeAnimatedText(
-              'do it RIGHT NOW!!!',
-              textStyle: _textStyleBold32,
-            ),
-          ],
-          onTap: onTap,
+        child: DefaultTextStyle(
+          style: const TextStyle(
+            fontSize: 32.0,
+            fontWeight: FontWeight.bold,
+          ),
+          child: AnimatedTextKit(
+            animatedTexts: [
+              FadeAnimatedText('do IT!'),
+              FadeAnimatedText('do it RIGHT!!'),
+              FadeAnimatedText('do it RIGHT NOW!!!'),
+            ],
+            onTap: onTap,
+          ),
         ),
       ),
       AnimatedTextExample(
@@ -225,26 +191,20 @@ List<AnimatedTextExample> animatedTextExamples({VoidCallback? onTap}) =>
         color: Colors.lightGreen[800],
         child: SizedBox(
           width: 250.0,
-          child: AnimatedTextKit(
-            animatedTexts: [
-              TyperAnimatedText(
-                'It is not enough to do your best,',
-                textStyle: _textStyleBobbers30,
-              ),
-              TyperAnimatedText(
-                'you must know what to do,',
-                textStyle: _textStyleBobbers30,
-              ),
-              TyperAnimatedText(
-                'and then do your best',
-                textStyle: _textStyleBobbers30,
-              ),
-              TyperAnimatedText(
-                '- W.Edwards Deming',
-                textStyle: _textStyleBobbers30,
-              ),
-            ],
-            onTap: onTap,
+          child: DefaultTextStyle(
+            style: const TextStyle(
+              fontSize: 30.0,
+              fontFamily: 'Bobbers',
+            ),
+            child: AnimatedTextKit(
+              animatedTexts: [
+                TyperAnimatedText('It is not enough to do your best,'),
+                TyperAnimatedText('you must know what to do,'),
+                TyperAnimatedText('and then do your best'),
+                TyperAnimatedText('- W.Edwards Deming'),
+              ],
+              onTap: onTap,
+            ),
           ),
         ),
       ),
@@ -253,48 +213,39 @@ List<AnimatedTextExample> animatedTextExamples({VoidCallback? onTap}) =>
         color: Colors.teal[700],
         child: SizedBox(
           width: 250.0,
-          child: AnimatedTextKit(
-            animatedTexts: [
-              TypewriterAnimatedText(
-                'Discipline is the best tool',
-                textStyle: _textStyleAgne30,
-              ),
-              TypewriterAnimatedText(
-                'Design first, then code',
-                textStyle: _textStyleAgne30,
-              ),
-              TypewriterAnimatedText(
-                'Do not patch bugs out, rewrite them',
-                textStyle: _textStyleAgne30,
-              ),
-              TypewriterAnimatedText(
-                'Do not test bugs out, design them out',
-                textStyle: _textStyleAgne30,
-              ),
-            ],
-            onTap: onTap,
+          child: DefaultTextStyle(
+            style: const TextStyle(
+              fontSize: 30.0,
+              fontFamily: 'Agne',
+            ),
+            child: AnimatedTextKit(
+              animatedTexts: [
+                TypewriterAnimatedText('Discipline is the best tool'),
+                TypewriterAnimatedText('Design first, then code'),
+                TypewriterAnimatedText('Do not patch bugs out, rewrite them'),
+                TypewriterAnimatedText('Do not test bugs out, design them out'),
+              ],
+              onTap: onTap,
+            ),
           ),
         ),
       ),
       AnimatedTextExample(
         label: 'Scale',
         color: Colors.blue[700],
-        child: AnimatedTextKit(
-          animatedTexts: [
-            ScaleAnimatedText(
-              'Think',
-              textStyle: _textStyleCanterbury70,
-            ),
-            ScaleAnimatedText(
-              'Build',
-              textStyle: _textStyleCanterbury70,
-            ),
-            ScaleAnimatedText(
-              'Ship',
-              textStyle: _textStyleCanterbury70,
-            ),
-          ],
-          onTap: onTap,
+        child: DefaultTextStyle(
+          style: const TextStyle(
+            fontSize: 70.0,
+            fontFamily: 'Canterbury',
+          ),
+          child: AnimatedTextKit(
+            animatedTexts: [
+              ScaleAnimatedText('Think'),
+              ScaleAnimatedText('Build'),
+              ScaleAnimatedText('Ship'),
+            ],
+            onTap: onTap,
+          ),
         ),
       ),
       AnimatedTextExample(
@@ -304,17 +255,17 @@ List<AnimatedTextExample> animatedTextExamples({VoidCallback? onTap}) =>
           animatedTexts: [
             ColorizeAnimatedText(
               'Larry Page',
-              textStyle: _textStyleHorizon50,
+              textStyle: _colorizeTextStyle,
               colors: _colorizeColors,
             ),
             ColorizeAnimatedText(
               'Bill Gates',
-              textStyle: _textStyleHorizon50,
+              textStyle: _colorizeTextStyle,
               colors: _colorizeColors,
             ),
             ColorizeAnimatedText(
               'Steve Jobs',
-              textStyle: _textStyleHorizon50,
+              textStyle: _colorizeTextStyle,
               colors: _colorizeColors,
             ),
           ],
@@ -338,22 +289,24 @@ List<AnimatedTextExample> animatedTextExamples({VoidCallback? onTap}) =>
       AnimatedTextExample(
         label: 'Wavy Text',
         color: Colors.black87,
-        child: AnimatedTextKit(
-          animatedTexts: [
-            WavyAnimatedText(
-              'Hello World',
-              textStyle: _textStyleDefault20,
-            ),
-            WavyAnimatedText(
-              'Look at the waves',
-              textStyle: _textStyleDefault20,
-            ),
-            WavyAnimatedText(
-              'They look so Amazing',
-              textStyle: _textStyleDefault20,
-            ),
-          ],
-          onTap: onTap,
+        child: DefaultTextStyle(
+          style: const TextStyle(
+            fontSize: 20.0,
+          ),
+          child: AnimatedTextKit(
+            animatedTexts: [
+              WavyAnimatedText(
+                'Hello World',
+                textStyle: const TextStyle(
+                  fontSize: 24.0,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              WavyAnimatedText('Look at the waves'),
+              WavyAnimatedText('They look so Amazing'),
+            ],
+            onTap: onTap,
+          ),
         ),
       ),
       AnimatedTextExample(

--- a/lib/src/animated_text.dart
+++ b/lib/src/animated_text.dart
@@ -13,7 +13,7 @@ abstract class AnimatedText {
   final TextAlign textAlign;
 
   /// [TextStyle] property for [Text] widget.
-  final TextStyle textStyle;
+  final TextStyle? textStyle;
 
   /// The Duration for the Animation Controller.
   ///
@@ -31,7 +31,7 @@ abstract class AnimatedText {
   AnimatedText({
     required this.text,
     this.textAlign = TextAlign.start,
-    required this.textStyle,
+    this.textStyle,
     required this.duration,
   }) : textCharacters = text.characters;
 
@@ -51,7 +51,7 @@ abstract class AnimatedText {
 
   /// Widget showing the complete text (when animation is complete or paused).
   /// By default, it shows a Text widget, but this may be overridden.
-  Widget completeText() => textWidget(text);
+  Widget completeText(BuildContext context) => textWidget(text);
 
   /// Widget showing animated text, based on animation value(s).
   Widget animatedBuilder(BuildContext context, Widget? child);
@@ -163,7 +163,7 @@ class _AnimatedTextKitState extends State<AnimatedTextKit>
 
   @override
   Widget build(BuildContext context) {
-    final completeText = _currentAnimatedText.completeText();
+    final completeText = _currentAnimatedText.completeText(context);
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: _onTap,

--- a/lib/src/colorize.dart
+++ b/lib/src/colorize.dart
@@ -27,7 +27,8 @@ class ColorizeAnimatedText extends AnimatedText {
     this.speed = const Duration(milliseconds: 200),
     required this.colors,
     this.textDirection = TextDirection.ltr,
-  })  : assert(colors.length > 1),
+  })  : assert(null != textStyle.fontSize),
+        assert(colors.length > 1),
         super(
           text: text,
           textAlign: textAlign,
@@ -41,8 +42,9 @@ class ColorizeAnimatedText extends AnimatedText {
 
   @override
   void initAnimation(AnimationController controller) {
+    // Note: This calculation is the only reason why [textStyle] is required
     final tuning = (300.0 * colors.length) *
-        (textStyle.fontSize! / 24.0) *
+        (textStyle!.fontSize! / 24.0) *
         0.75 *
         (textCharacters.length / 15.0);
 
@@ -85,16 +87,18 @@ class ColorizeAnimatedText extends AnimatedText {
   }
 
   @override
-  Widget completeText() {
+  Widget completeText(BuildContext context) {
     final linearGradient = LinearGradient(colors: _colors).createShader(
       Rect.fromLTWH(0.0, 0.0, _colorShifter.value, 0.0),
     );
-    return Text(
-      text,
-      style: textStyle.merge(
-        TextStyle(foreground: Paint()..shader = linearGradient),
+
+    return DefaultTextStyle.merge(
+      style: textStyle,
+      child: Text(
+        text,
+        style: TextStyle(foreground: Paint()..shader = linearGradient),
+        textAlign: textAlign,
       ),
-      textAlign: textAlign,
     );
   }
 
@@ -102,7 +106,7 @@ class ColorizeAnimatedText extends AnimatedText {
   Widget animatedBuilder(BuildContext context, Widget? child) {
     return Opacity(
       opacity: _fadeIn.value != 1.0 ? _fadeIn.value : _fadeOut.value,
-      child: completeText(),
+      child: completeText(context),
     );
   }
 }

--- a/lib/src/fade.dart
+++ b/lib/src/fade.dart
@@ -13,7 +13,7 @@ class FadeAnimatedText extends AnimatedText {
   FadeAnimatedText(
     String text, {
     TextAlign textAlign = TextAlign.start,
-    required TextStyle textStyle,
+    TextStyle? textStyle,
     Duration duration = const Duration(milliseconds: 2000),
     this.fadeInEnd = 0.5,
     this.fadeOutBegin = 0.8,
@@ -46,7 +46,7 @@ class FadeAnimatedText extends AnimatedText {
   }
 
   @override
-  Widget completeText() => SizedBox.shrink();
+  Widget completeText(BuildContext context) => SizedBox.shrink();
 
   @override
   Widget animatedBuilder(BuildContext context, Widget? child) {
@@ -66,7 +66,7 @@ class FadeAnimatedTextKit extends AnimatedTextKit {
     Key? key,
     required List<String> text,
     TextAlign textAlign = TextAlign.start,
-    required TextStyle textStyle,
+    TextStyle? textStyle,
     Duration duration = const Duration(milliseconds: 2000),
     Duration pause = const Duration(milliseconds: 500),
     double fadeInEnd = 0.5,
@@ -99,7 +99,7 @@ class FadeAnimatedTextKit extends AnimatedTextKit {
   static List<AnimatedText> _animatedTexts(
     List<String> text,
     TextAlign textAlign,
-    TextStyle textStyle,
+    TextStyle? textStyle,
     Duration duration,
     double fadeInEnd,
     double fadeOutBegin,

--- a/lib/src/rotate.dart
+++ b/lib/src/rotate.dart
@@ -30,20 +30,16 @@ class RotateAnimatedText extends AnimatedText {
   /// By default, it is set to true.
   final bool rotateOut;
 
-  /// Effective Transition Height
-  final double _transitionHeight;
-
   RotateAnimatedText(
     String text, {
     TextAlign textAlign = TextAlign.start,
-    required TextStyle textStyle,
+    TextStyle? textStyle,
     Duration duration = const Duration(milliseconds: 2000),
     this.transitionHeight,
     this.alignment = Alignment.center,
     this.textDirection = TextDirection.ltr,
     this.rotateOut = true,
-  })  : _transitionHeight = transitionHeight ?? (textStyle.fontSize! * 10 / 3),
-        super(
+  }) : super(
           text: text,
           textAlign: textAlign,
           textStyle: textStyle,
@@ -97,12 +93,16 @@ class RotateAnimatedText extends AnimatedText {
   }
 
   @override
-  Widget completeText() => rotateOut ? SizedBox.shrink() : super.completeText();
+  Widget completeText(BuildContext context) =>
+      rotateOut ? SizedBox.shrink() : super.completeText(context);
 
   @override
   Widget animatedBuilder(BuildContext context, Widget? child) {
+    final fontSize =
+        textStyle?.fontSize ?? DefaultTextStyle.of(context).style.fontSize;
+
     return SizedBox(
-      height: _transitionHeight,
+      height: transitionHeight ?? (fontSize! * 10 / 3),
       child: AlignTransition(
         alignment: _slideIn.value.y != 0.0 || !rotateOut ? _slideIn : _slideOut,
         child: Opacity(
@@ -125,7 +125,7 @@ class RotateAnimatedTextKit extends AnimatedTextKit {
     Key? key,
     required List<String> text,
     TextAlign textAlign = TextAlign.start,
-    required TextStyle textStyle,
+    TextStyle? textStyle,
     double? transitionHeight,
     AlignmentGeometry alignment = Alignment.center,
     TextDirection textDirection = TextDirection.ltr,
@@ -166,7 +166,7 @@ class RotateAnimatedTextKit extends AnimatedTextKit {
   static List<AnimatedText> _animatedTexts(
     List<String> text,
     TextAlign textAlign,
-    TextStyle textStyle,
+    TextStyle? textStyle,
     Duration duration,
     double? transitionHeight,
     AlignmentGeometry alignment,

--- a/lib/src/scale.dart
+++ b/lib/src/scale.dart
@@ -13,7 +13,7 @@ class ScaleAnimatedText extends AnimatedText {
   ScaleAnimatedText(
     String text, {
     TextAlign textAlign = TextAlign.start,
-    required TextStyle textStyle,
+    TextStyle? textStyle,
     Duration duration = const Duration(milliseconds: 2000),
     this.scalingFactor = 0.5,
   }) : super(
@@ -56,7 +56,7 @@ class ScaleAnimatedText extends AnimatedText {
   }
 
   @override
-  Widget completeText() => SizedBox.shrink();
+  Widget completeText(BuildContext context) => SizedBox.shrink();
 
   @override
   Widget animatedBuilder(BuildContext context, Widget? child) {
@@ -79,7 +79,7 @@ class ScaleAnimatedTextKit extends AnimatedTextKit {
     Key? key,
     required List<String> text,
     TextAlign textAlign = TextAlign.start,
-    required TextStyle textStyle,
+    TextStyle? textStyle,
     double scalingFactor = 0.5,
     Duration duration = const Duration(milliseconds: 2000),
     Duration pause = const Duration(milliseconds: 500),
@@ -116,7 +116,7 @@ class ScaleAnimatedTextKit extends AnimatedTextKit {
   static List<AnimatedText> _animatedTexts(
     List<String> text,
     TextAlign textAlign,
-    TextStyle textStyle,
+    TextStyle? textStyle,
     Duration duration,
     double scalingFactor,
   ) =>

--- a/lib/src/typer.dart
+++ b/lib/src/typer.dart
@@ -20,7 +20,7 @@ class TyperAnimatedText extends AnimatedText {
   TyperAnimatedText(
     String text, {
     TextAlign textAlign = TextAlign.start,
-    required TextStyle textStyle,
+    TextStyle? textStyle,
     this.speed = const Duration(milliseconds: 40),
     this.curve = Curves.linear,
   }) : super(
@@ -65,7 +65,7 @@ class TyperAnimatedTextKit extends AnimatedTextKit {
     Key? key,
     required List<String> text,
     TextAlign textAlign = TextAlign.start,
-    required TextStyle textStyle,
+    TextStyle? textStyle,
     Duration speed = const Duration(milliseconds: 40),
     Duration pause = const Duration(milliseconds: 1000),
     bool displayFullTextOnTap = false,
@@ -97,7 +97,7 @@ class TyperAnimatedTextKit extends AnimatedTextKit {
   static List<AnimatedText> _animatedTexts(
     List<String> text,
     TextAlign textAlign,
-    TextStyle textStyle,
+    TextStyle? textStyle,
     Duration speed,
     Curve curve,
   ) =>

--- a/lib/src/typewriter.dart
+++ b/lib/src/typewriter.dart
@@ -23,7 +23,7 @@ class TypewriterAnimatedText extends AnimatedText {
   TypewriterAnimatedText(
     String text, {
     TextAlign textAlign = TextAlign.start,
-    required TextStyle textStyle,
+    TextStyle? textStyle,
     this.speed = const Duration(milliseconds: 30),
     this.curve = Curves.linear,
   }) : super(
@@ -48,16 +48,16 @@ class TypewriterAnimatedText extends AnimatedText {
   }
 
   @override
-  Widget completeText() => RichText(
+  Widget completeText(BuildContext context) => RichText(
         text: TextSpan(
           children: [
             TextSpan(text: text),
             TextSpan(
               text: '_',
-              style: textStyle.copyWith(color: Colors.transparent),
+              style: const TextStyle(color: Colors.transparent),
             )
           ],
-          style: textStyle,
+          style: DefaultTextStyle.of(context).style.merge(textStyle),
         ),
         textAlign: textAlign,
       );
@@ -72,17 +72,15 @@ class TypewriterAnimatedText extends AnimatedText {
             (textCharacters.length + extraLengthForBlinks))
         .round();
 
+    var showCursor = true;
     var visibleString = text;
-    Color? suffixColor = Colors.transparent;
     if (typewriterValue == 0) {
       visibleString = '';
+      showCursor = false;
     } else if (typewriterValue > textLen) {
-      suffixColor = (typewriterValue - textLen) % 2 == 0
-          ? textStyle.color
-          : Colors.transparent;
+      showCursor = (typewriterValue - textLen) % 2 == 0;
     } else {
       visibleString = textCharacters.take(typewriterValue).toString();
-      suffixColor = textStyle.color;
     }
 
     return RichText(
@@ -91,10 +89,11 @@ class TypewriterAnimatedText extends AnimatedText {
           TextSpan(text: visibleString),
           TextSpan(
             text: '_',
-            style: textStyle.copyWith(color: suffixColor),
+            style:
+                showCursor ? null : const TextStyle(color: Colors.transparent),
           )
         ],
-        style: textStyle,
+        style: DefaultTextStyle.of(context).style.merge(textStyle),
       ),
       textAlign: textAlign,
     );

--- a/lib/src/wavy.dart
+++ b/lib/src/wavy.dart
@@ -15,7 +15,7 @@ class WavyAnimatedText extends AnimatedText {
   WavyAnimatedText(
     String text, {
     TextAlign textAlign = TextAlign.start,
-    required TextStyle textStyle,
+    TextStyle? textStyle,
     this.speed = const Duration(milliseconds: 300),
   }) : super(
           text: text,
@@ -40,7 +40,7 @@ class WavyAnimatedText extends AnimatedText {
         foregroundPainter: _WTextPainter(
           progress: _waveAnim.value,
           text: text,
-          textStyle: textStyle,
+          textStyle: DefaultTextStyle.of(context).style.merge(textStyle),
         ),
       ),
     );
@@ -57,7 +57,7 @@ class WavyAnimatedTextKit extends AnimatedTextKit {
     Key? key,
     required List<String> text,
     TextAlign textAlign = TextAlign.start,
-    required TextStyle textStyle,
+    TextStyle? textStyle,
     Duration speed = const Duration(milliseconds: 300),
     Duration pause = const Duration(milliseconds: 1000),
     VoidCallback? onTap,
@@ -87,7 +87,7 @@ class WavyAnimatedTextKit extends AnimatedTextKit {
   static List<AnimatedText> _animatedTexts(
     List<String> text,
     TextAlign textAlign,
-    TextStyle textStyle,
+    TextStyle? textStyle,
     Duration speed,
   ) =>
       text
@@ -189,7 +189,10 @@ class _WTextPainter extends CustomPainter {
   void drawText(Canvas canvas, String text, Offset offset,
       _TextLayoutInfo textLayoutInfo) {
     var textPainter = TextPainter(
-      text: TextSpan(text: text, style: textStyle),
+      text: TextSpan(
+        text: text,
+        style: textStyle,
+      ),
       textDirection: TextDirection.ltr,
     )..layout();
 
@@ -207,7 +210,10 @@ class _WTextPainter extends CustomPainter {
 
     // creating a textPainter to get data about location and offset for chars
     final textPainter = TextPainter(
-      text: TextSpan(text: text, style: textStyle),
+      text: TextSpan(
+        text: text,
+        style: textStyle,
+      ),
       textDirection: TextDirection.ltr,
       maxLines: 1,
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: animated_text_kit
 description: A flutter package project which contains a collection of cool and beautiful text animations.
-version: 4.0.0
+version: 4.1.0
 homepage: https://github.com/aagarwal1012/Animated-Text-Kit/
 maintainer: Ayush Agarwal (@aagarwal1012)
 


### PR DESCRIPTION
* Revised the `example` and `README` to use [DefaultTextStyle](https://api.flutter.dev/flutter/widgets/DefaultTextStyle-class.html) to easily impact multiple `AnimatedText` instances
* Resolves #215
* Advanced the version to 4.1.0 and updated the `CHANGELOG`