### PR TITLE
Deploy 1pub

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,4 +1,4 @@
-name: Deploy Animated Text Kit Example to Preview Channel
+name: Deploy Example to Preview Channel
 
 on:
   pull_request:
@@ -16,8 +16,8 @@ jobs:
       - run: flutter build web
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
           expires: 30d
-          entryPoint: "./example"
           projectId: animated-text-kit
+          entryPoint: "./example"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,6 +1,4 @@
-# .github/workflows/deploy-preview.yml
-
-name: Deploy to Preview Channel
+name: Deploy Animated Text Kit Example to Preview Channel
 
 on:
   pull_request:
@@ -15,13 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
-      - run: |
-          flutter pub get
-          flutter build web --release
+      - run: flutter build web
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           expires: 30d
-          entryPoint: "./example" 
+          entryPoint: "./example"
           projectId: animated-text-kit

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,4 +1,4 @@
-name: Deploy Animated Text Kit Example to Live Channel
+name: Deploy Example to Live Channel
 
 on:
   push:
@@ -18,8 +18,8 @@ jobs:
       - run: flutter build web
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
           projectId: animated-text-kit
-          entryPoint: "./example"
           channelId: live
+          entryPoint: "./example"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,6 +1,4 @@
-# .github/workflows/deploy-prod.yml
-
-name: Deploy to Live Channel
+name: Deploy Animated Text Kit Example to Live Channel
 
 on:
   push:
@@ -17,9 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
-      - run: |
-          flutter pub get
-          flutter build web --release
+      - run: flutter build web
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Minor tweaks to the Firebase Hosting deployment actions.
* Elaborated the action `name`
* Removed the redundant `flutter pub get` since `flutter build` will also run it
* Removed the `--release` switch from `flutter build`, since it is the default