### PR TITLE
Simplified web build

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,5 +1,3 @@
-# .github/workflows/deploy-preview.yml
-
 name: Deploy to Preview Channel
 
 on:
@@ -15,13 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
-      - run: |
-          flutter pub get
-          flutter build web --release
+      - run: flutter build web
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
           expires: 30d
-          entryPoint: "./example" 
+          entryPoint: "./example"
           projectId: animated-text-kit

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,5 +1,3 @@
-# .github/workflows/deploy-prod.yml
-
 name: Deploy to Live Channel
 
 on:
@@ -17,9 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
-      - run: |
-          flutter pub get
-          flutter build web --release
+      - run: flutter build web
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Minor tweaks to the Firebase Hosting deployment actions.
* Removed the redundant `flutter pub get` since `flutter build` will also run it
* Removed the `--release` switch from `flutter build`, since it is the default