### PR TITLE
setState text workaround solution added in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,6 @@ AnimatedTextKit(
 )
 ```
 
-**Note:** You might come up with an issue that the `text` does not get updated with `setState` as shown [here](https://github.com/aagarwal1012/Animated-Text-Kit/issues/27). The solution to this, is a key that changes based on the text. For reference, watch [this](https://www.youtube.com/watch?v=kn0EOS-ZiIc) video.
-
 It has many configurable properties, including:
 
 - `pause` – the time of the pause between animation texts
@@ -152,6 +150,8 @@ There are also custom callbacks:
 - `onNext(int index, bool isLast)` – This is called before the next text animation, after the previous one's pause
 - `onNextBeforePause(int index, bool isLast)` – This is called before the next text animation, before the previous one's pause
 - `onFinished` - This is called at the end, when the parameter `isRepeatingAnimation` is set to `false`
+
+**Note:** You might come up with an issue that the `text` does not get updated with `setState` as shown [here](https://github.com/aagarwal1012/Animated-Text-Kit/issues/27). The solution to this, is a key that changes based on the text. For reference, watch [this](https://www.youtube.com/watch?v=kn0EOS-ZiIc) video.
 
 ## New with Version 3
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ AnimatedTextKit(
 )
 ```
 
+**Note:** You might come up with an issue that the `text` does not get updated with `setState` as shown [here](https://github.com/aagarwal1012/Animated-Text-Kit/issues/27). The solution to this, is a key that changes based on the text. For reference, watch [this](https://www.youtube.com/watch?v=kn0EOS-ZiIc) video.
+
 It has many configurable properties, including:
 
 - `pause` – the time of the pause between animation texts
@@ -488,8 +490,6 @@ AnimatedTextKit(
   ],
 ),
 ```
-
-**Note:** You might come up with an issue that the `text` does not get updated with `setState` as shown [here](https://github.com/aagarwal1012/Animated-Text-Kit/issues/27).The solution to this, is a key that changes based on the text. For reference, watch [this](https://www.youtube.com/watch?v=kn0EOS-ZiIc) video.
 
 # Bugs or Requests
 

--- a/README.md
+++ b/README.md
@@ -489,6 +489,8 @@ AnimatedTextKit(
 ),
 ```
 
+**Note:** You might come up with an issue that the `text` does not get updated with `setState` as shown [here](https://github.com/aagarwal1012/Animated-Text-Kit/issues/27).The solution to this, is a key that changes based on the text. For reference, watch [this](https://www.youtube.com/watch?v=kn0EOS-ZiIc) video.
+
 # Bugs or Requests
 
 If you encounter any problems feel free to open an [issue](https://github.com/aagarwal1012/Animated-Text-Kit/issues/new?template=bug_report.md). If you feel the library is missing a feature, please raise a [ticket](https://github.com/aagarwal1012/Animated-Text-Kit/issues/new?template=feature_request.md) on GitHub and I'll look into it. Pull request are also welcome.


### PR DESCRIPTION
Fixes #198 

1. Wrote the `setState` `text` issue in the README file.
2. Added the solution (a `key` that changes based on the `text`) along with the video by Google Developers.

Please tell if anything else needs to be added  - Like flutter documentation, etc.