### PR TITLE
Update pub.dev links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.2+1
+
+- Add issue-tracker link to pub.dev
+
 ## 4.2.2
 
 - Removed unused import statements.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,8 @@
 name: animated_text_kit
 description: A flutter package project which contains a collection of cool and beautiful text animations.
 version: 4.2.2
-homepage: https://github.com/aagarwal1012/Animated-Text-Kit/
+repository: https://github.com/aagarwal1012/Animated-Text-Kit/
+issue_tracker: https://github.com/aagarwal1012/Animated-Text-Kit/issues
 maintainer: Ayush Agarwal (@aagarwal1012)
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: animated_text_kit
 description: A flutter package project which contains a collection of cool and beautiful text animations.
-version: 4.2.2
+version: 4.2.2+1
 repository: https://github.com/aagarwal1012/Animated-Text-Kit/
 issue_tracker: https://github.com/aagarwal1012/Animated-Text-Kit/issues
 maintainer: Ayush Agarwal (@aagarwal1012)


### PR DESCRIPTION
With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).