### PR TITLE
An option to show animated texts without overriding it

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ It has many configurable properties, including:
 - `isRepeatingAnimation` – controls whether the animation repeats
 - `repeatForever` – controls whether the animation repeats forever
 - `totalRepeatCount` – number of times the animation should repeat (when `repeatForever` is `false`)
+- `overrideTexts` – it allows to show animated texts without override it (default is `true`)
 
 There are also custom callbacks:
 

--- a/lib/src/animated_text.dart
+++ b/lib/src/animated_text.dart
@@ -72,6 +72,9 @@ class AnimatedTextKit extends StatefulWidget {
   /// By default it is set to false.
   final bool displayFullTextOnTap;
 
+  ///Overrides previous text to other one. It's true by default
+  final bool overrideTexts;
+
   /// If on pause, should a tap remove the remaining pause time ?
   ///
   /// By default it is set to false.
@@ -117,6 +120,7 @@ class AnimatedTextKit extends StatefulWidget {
     this.pause = const Duration(milliseconds: 1000),
     this.displayFullTextOnTap = false,
     this.stopPauseOnTap = false,
+    this.overrideTexts = true,
     this.onTap,
     this.onNext,
     this.onNextBeforePause,
@@ -165,16 +169,26 @@ class _AnimatedTextKitState extends State<AnimatedTextKit>
   Widget build(BuildContext context) {
     final completeText = _currentAnimatedText.completeText(context);
     return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: _onTap,
-      child: _isCurrentlyPausing || !_controller.isAnimating
-          ? completeText
-          : AnimatedBuilder(
-              animation: _controller,
-              builder: _currentAnimatedText.animatedBuilder,
-              child: completeText,
-            ),
-    );
+        behavior: HitTestBehavior.opaque,
+        onTap: _onTap,
+        child: Column(
+          children: widget.animatedTexts
+                  .take(_index)
+                  .map<Widget>((e) => Text(
+                        e.text,
+                        style: e.textStyle,
+                      ))
+                  .toList() +
+              [
+                _isCurrentlyPausing || !_controller.isAnimating
+                    ? completeText
+                    : AnimatedBuilder(
+                        animation: _controller,
+                        builder: _currentAnimatedText.animatedBuilder,
+                        child: completeText,
+                      )
+              ],
+        ));
   }
 
   bool get _isLast => _index == widget.animatedTexts.length - 1;

--- a/lib/src/animated_text.dart
+++ b/lib/src/animated_text.dart
@@ -167,31 +167,35 @@ class _AnimatedTextKitState extends State<AnimatedTextKit>
 
   @override
   Widget build(BuildContext context) {
-    final completeText = _currentAnimatedText.completeText(context);
     return GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: _onTap,
-        child: Column(
-          children: widget.animatedTexts
-                  .take(_index)
-                  .map<Widget>((e) => Text(
-                        e.text,
-                        style: e.textStyle,
-                      ))
-                  .toList() +
-              [
-                _isCurrentlyPausing || !_controller.isAnimating
-                    ? completeText
-                    : AnimatedBuilder(
-                        animation: _controller,
-                        builder: _currentAnimatedText.animatedBuilder,
-                        child: completeText,
-                      )
-              ],
-        ));
+      behavior: HitTestBehavior.opaque,
+      onTap: _onTap,
+      child: widget.overrideTexts
+          ? _animationRenderer()
+          : Column(
+              children: widget.animatedTexts
+                      .take(_index)
+                      .map<Widget>((e) => Text(
+                            e.text,
+                            style: e.textStyle,
+                          ))
+                      .toList() +
+                  [_animationRenderer()],
+            ),
+    );
   }
 
   bool get _isLast => _index == widget.animatedTexts.length - 1;
+
+  Widget _animationRenderer() {
+    final completeText = _currentAnimatedText.completeText(context);
+    return _isCurrentlyPausing || !_controller.isAnimating
+        ? completeText
+        : AnimatedBuilder(
+            animation: _controller,
+            builder: _currentAnimatedText.animatedBuilder,
+            child: completeText);
+  }
 
   void _nextAnimation() {
     final isLast = _isLast;


### PR DESCRIPTION
## Purpose of request:

It allows showing animated texts without overriding.

Before:
(overrideTexts: false) ==> Still preserved by default
<img src="https://media.giphy.com/media/kkR2KfQvKGgbqOiUTn/giphy.gif"/>

After
(overrideTexts: true)
<img src="https://media.giphy.com/media/lZ3VSqclOp5VeUCr9A/giphy.gif"/>