### PR TITLE
Add Slide Direction Enum to Control Slide-In and Slide-Out Direction on `RotateAnimatedText`

### DIFF
--- a/lib/src/rotate.dart
+++ b/lib/src/rotate.dart
@@ -249,11 +249,3 @@ class RotateAnimatedTextKit extends AnimatedTextKit {
               ))
           .toList();
 }
-
-// Hi, I'm Yashas this will be my first contribution.
-//
-// I had a pretty cool idea when I was working on a todo app, I wanted to mark the task as done and strikethrough the text but there was no option to do so with an animation. I looked through various libraries but wasn't able to find a good one.
-//
-// I have been using animated text kit for some time a now and thought of contributing to the library by adding a strike through animation.
-//
-// Is anyone working on this? If not, may I contribute to this?

--- a/lib/src/rotate.dart
+++ b/lib/src/rotate.dart
@@ -70,7 +70,7 @@ class RotateAnimatedText extends AnimatedText {
 
     final inIntervalEnd = rotateOut ? 0.4 : 1.0;
 
-    AlignmentTween slideInTween;
+    late final AlignmentTween slideInTween;
     switch (slideDirection) {
       case SlideDirection.leftToRight:
         slideInTween = AlignmentTween(
@@ -113,7 +113,7 @@ class RotateAnimatedText extends AnimatedText {
     );
 
     if (rotateOut) {
-      AlignmentTween slideOutTween;
+      late final AlignmentTween slideOutTween;
       switch (slideDirection) {
         case SlideDirection.leftToRight:
           slideOutTween = AlignmentTween(

--- a/lib/src/rotate.dart
+++ b/lib/src/rotate.dart
@@ -53,7 +53,7 @@ class RotateAnimatedText extends AnimatedText {
     this.alignment = Alignment.center,
     this.textDirection = TextDirection.ltr,
     this.rotateOut = true,
-    this.slideDirection = SlideDirection.bottomToTop,
+    this.slideDirection = SlideDirection.topToBottom,
   }) : super(
           text: text,
           textAlign: textAlign,

--- a/lib/src/rotate.dart
+++ b/lib/src/rotate.dart
@@ -1,5 +1,14 @@
 import 'package:flutter/material.dart';
+
 import 'animated_text.dart';
+
+/// Enum to control the slide direction.
+enum SlideDirection {
+  leftToRight,
+  rightToLeft,
+  topToBottom,
+  bottomToTop,
+}
 
 /// Animated Text that rotates a [Text] in and then out.
 ///
@@ -30,6 +39,11 @@ class RotateAnimatedText extends AnimatedText {
   /// By default, it is set to true.
   final bool rotateOut;
 
+  /// Control slide animation direction.
+  ///
+  /// By default. it is set to [SlideDirection.topToBottom]
+  final SlideDirection slideDirection;
+
   RotateAnimatedText(
     String text, {
     TextAlign textAlign = TextAlign.start,
@@ -39,6 +53,7 @@ class RotateAnimatedText extends AnimatedText {
     this.alignment = Alignment.center,
     this.textDirection = TextDirection.ltr,
     this.rotateOut = true,
+    this.slideDirection = SlideDirection.bottomToTop,
   }) : super(
           text: text,
           textAlign: textAlign,
@@ -55,10 +70,35 @@ class RotateAnimatedText extends AnimatedText {
 
     final inIntervalEnd = rotateOut ? 0.4 : 1.0;
 
-    _slideIn = AlignmentTween(
-      begin: Alignment.topCenter.add(alignment).resolve(direction),
-      end: Alignment.center.add(alignment).resolve(direction),
-    ).animate(
+    AlignmentTween slideInTween;
+    switch (slideDirection) {
+      case SlideDirection.leftToRight:
+        slideInTween = AlignmentTween(
+          begin: Alignment.centerLeft.add(alignment).resolve(direction),
+          end: Alignment.center.add(alignment).resolve(direction),
+        );
+        break;
+      case SlideDirection.rightToLeft:
+        slideInTween = AlignmentTween(
+          begin: Alignment.centerRight.add(alignment).resolve(direction),
+          end: Alignment.center.add(alignment).resolve(direction),
+        );
+        break;
+      case SlideDirection.topToBottom:
+        slideInTween = AlignmentTween(
+          begin: Alignment.topCenter.add(alignment).resolve(direction),
+          end: Alignment.center.add(alignment).resolve(direction),
+        );
+        break;
+      case SlideDirection.bottomToTop:
+        slideInTween = AlignmentTween(
+          begin: Alignment.bottomCenter.add(alignment).resolve(direction),
+          end: Alignment.center.add(alignment).resolve(direction),
+        );
+        break;
+    }
+
+    _slideIn = slideInTween.animate(
       CurvedAnimation(
         parent: controller,
         curve: Interval(0.0, inIntervalEnd, curve: Curves.linear),
@@ -73,10 +113,35 @@ class RotateAnimatedText extends AnimatedText {
     );
 
     if (rotateOut) {
-      _slideOut = AlignmentTween(
-        begin: Alignment.center.add(alignment).resolve(direction),
-        end: Alignment.bottomCenter.add(alignment).resolve(direction),
-      ).animate(
+      AlignmentTween slideOutTween;
+      switch (slideDirection) {
+        case SlideDirection.leftToRight:
+          slideOutTween = AlignmentTween(
+            begin: Alignment.center.add(alignment).resolve(direction),
+            end: Alignment.centerRight.add(alignment).resolve(direction),
+          );
+          break;
+        case SlideDirection.rightToLeft:
+          slideOutTween = AlignmentTween(
+            begin: Alignment.center.add(alignment).resolve(direction),
+            end: Alignment.centerLeft.add(alignment).resolve(direction),
+          );
+          break;
+        case SlideDirection.topToBottom:
+          slideOutTween = AlignmentTween(
+            begin: Alignment.center.add(alignment).resolve(direction),
+            end: Alignment.bottomCenter.add(alignment).resolve(direction),
+          );
+          break;
+        case SlideDirection.bottomToTop:
+          slideOutTween = AlignmentTween(
+            begin: Alignment.center.add(alignment).resolve(direction),
+            end: Alignment.topCenter.add(alignment).resolve(direction),
+          );
+          break;
+      }
+
+      _slideOut = slideOutTween.animate(
         CurvedAnimation(
           parent: controller,
           curve: const Interval(0.7, 1.0, curve: Curves.linear),
@@ -184,3 +249,11 @@ class RotateAnimatedTextKit extends AnimatedTextKit {
               ))
           .toList();
 }
+
+// Hi, I'm Yashas this will be my first contribution.
+//
+// I had a pretty cool idea when I was working on a todo app, I wanted to mark the task as done and strikethrough the text but there was no option to do so with an animation. I looked through various libraries but wasn't able to find a good one.
+//
+// I have been using animated text kit for some time a now and thought of contributing to the library by adding a strike through animation.
+//
+// Is anyone working on this? If not, may I contribute to this?


### PR DESCRIPTION
### Summary

This pull request addresses Issue #323, where I propose adding a new enum, `SlideDirection`, to the `RotateAnimatedText` widget in the Animated-Text-Kit Flutter package. This enhancement allows users to specify the direction of slide-in and slide-out animations for text, providing greater flexibility and customization options.

### Changes Made

- Introduced the `SlideDirection` enum at the top of the `RotateAnimatedText` file, enabling users to choose the slide direction.
- Modified the `RotateAnimatedText` constructor to accept a `slideDirection` property, allowing users to specify the desired slide direction when creating an instance of `RotateAnimatedText`.
- Updated the `initAnimation` method to use the `slideDirection` property to determine the slide direction for both slide-in and slide-out animations.
- Ensured that the default behavior matches the current behavior for existing users who don't specify a `slideDirection`.

### Testing Done

- Tested the new `slideDirection` property with various values to ensure that the slide animations behave as expected.
- Ensured that existing functionality remains unaffected by this change.

### Screenshots 

Working on it.

### Closes Issues

Closes #323 

### Checklist

- [x] I have read and followed the [Contributing Guidelines](https://github.com/aagarwal1012/Animated-Text-Kit/blob/master/CONTRIBUTING.md).
- [x] I have tested the changes locally and verified that they work as intended.
- [x] The code adheres to the project's coding style and conventions.

### Notes
Please tell if anything else needs to be added - Like flutter documentation, etc.
