### PR TITLE
Removed test for channel dev 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [stable, beta, dev]
+        channel: [stable, beta]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Removed the test for the dev channel in the  pipeline as the  dev channel is deprecated. Flutter recommends to use only `stable` and `beta` for development. 